### PR TITLE
Inspiration expiration buttons connected

### DIFF
--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -26,6 +26,10 @@ esp_settable_param:
 # This is the string returned by the ESP in case of success
 return_success_code: 'OK'
 
+# The interval used to send 1 to the ESP if expiration or espiration 
+# paused button is pressed (in seconds)
+expinsp_setinterval: 0.1 
+
 # Thickness of the lines drawn in the plots
 line_width: 1
 

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -121,6 +121,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._data_h.connect_data_filler(self.data_filler)
         self._data_h.start_io_thread()
 
+        self.menu.connect_datahandler_config(self._data_h, self.config)
+
+
 
         '''
         Set up tool settings (bottom bar)

--- a/gui/menu/menu.py
+++ b/gui/menu/menu.py
@@ -13,7 +13,6 @@ class Menu(QtWidgets.QWidget):
         super(Menu, self).__init__(*args)
         uic.loadUi("menu/menu.ui", self)
 
-        self._configured = False
 
         self.button_expause.pressed.connect(lambda: self.paused_pressed('pause_exhale'))
         self.button_expause.released.connect(lambda: self.paused_released('pause_exhale'))
@@ -26,16 +25,18 @@ class Menu(QtWidgets.QWidget):
         '''
         Passes the data handler and the confi dict to this class.
         '''
-        self._configured = True
         self._data_h = data_h
         self._config = config
+
+    def is_configured(self):
+        return hasattr(self, "_data_h") and hasattr(self, "_config")
 
     def paused_pressed(self, mode):
         '''
         Called when either the inspiration ot expiration pause
         buttons are pressed.
         '''
-        if not self._configured:
+        if not self.is_configured():
             raise Exception('Need to call connect_config_esp first.')
         if mode not in ['pause_exhale', 'pause_inhale']:
             raise Exception('Can only call paused_pressed with pause_exhale or pause_inhale.')
@@ -51,7 +52,7 @@ class Menu(QtWidgets.QWidget):
         Called when either the inspiration ot expiration pause
         buttons are released.
         '''
-        if not self._configured:
+        if not self.is_configured():
             raise Exception('Need to call connect_config_esp first.')
         if mode not in ['pause_exhale', 'pause_inhale']:
             raise Exception('Can only call paused_pressed with pause_exhale or pause_inhale.')

--- a/gui/menu/menu.py
+++ b/gui/menu/menu.py
@@ -56,8 +56,7 @@ class Menu(QtWidgets.QWidget):
         if mode not in ['pause_exhale', 'pause_inhale']:
             raise Exception('Can only call paused_pressed with pause_exhale or pause_inhale.')
 
-        if hasattr(self, '_timer'):
-            self._timer.stop()
+        self.stop_timer()
 
         self.send_signal(mode=mode, pause=False)
 
@@ -67,12 +66,24 @@ class Menu(QtWidgets.QWidget):
         Sends signal the appropriate signal the ESP
         to pause inpiration or expiration. 
         '''
-        if not self._data_h.set_data(mode, int(pause)):
+        try:
+            if not self._data_h.set_data(mode, int(pause)):
+                raise Exception('Call to set_data failed.')
+        except Exception as error:
             msg = MessageBox()
             fn = msg.critical("Critical",
                               "Severe hardware communication error",
-                              "Cannot set %s to ESP32." % mode, 
+                              str(error), 
                               "Communication error",
-                              { msg.Ok: lambda: self.paused_released(mode) })
+                              { msg.Ok: lambda: self.stop_timer() })
             fn()
+
+    def stop_timer(self):
+        '''
+        Stops the QTimer which sends 
+        signals to the ESP
+        '''
+        if hasattr(self, '_timer'):
+            self._timer.stop()
+
 

--- a/gui/menu/menu.py
+++ b/gui/menu/menu.py
@@ -45,7 +45,6 @@ class Menu(QtWidgets.QWidget):
         self._timer.timeout.connect(lambda: self.send_signal(mode)) 
         self._timer.start(self._config['expinsp_setinterval'])
 
-        print('hi!')
 
     def paused_released(self, mode):
         '''

--- a/gui/menu/menu.py
+++ b/gui/menu/menu.py
@@ -24,6 +24,7 @@ class Menu(QtWidgets.QWidget):
 
     def connect_datahandler_config(self, data_h, config):
         '''
+        Passes the data handler and the confi dict to this class.
         '''
         self._configured = True
         self._data_h = data_h
@@ -31,6 +32,8 @@ class Menu(QtWidgets.QWidget):
 
     def paused_pressed(self, mode):
         '''
+        Called when either the inspiration ot expiration pause
+        buttons are pressed.
         '''
         if not self._configured:
             raise Exception('Need to call connect_config_esp first.')
@@ -46,6 +49,8 @@ class Menu(QtWidgets.QWidget):
 
     def paused_released(self, mode):
         '''
+        Called when either the inspiration ot expiration pause
+        buttons are released.
         '''
         if not self._configured:
             raise Exception('Need to call connect_config_esp first.')
@@ -58,12 +63,14 @@ class Menu(QtWidgets.QWidget):
 
     def send_signal(self, mode):
         '''
+        Sends signal the appropriate signal the ESP
+        to pause inpiration or expiration. 
         '''
         if not self._data_h.set_data(mode, 1):
             msg = MessageBox()
             fn = msg.critical("Critical",
                               "Severe hardware communication error",
-                              "Cannot pause inspiration/expiration.", 
+                              "Cannot set %s to ESP32." % mode, 
                               "Communication error",
                               { msg.Ok: lambda: self.paused_released(mode) })
             fn()

--- a/gui/menu/menu.py
+++ b/gui/menu/menu.py
@@ -43,7 +43,7 @@ class Menu(QtWidgets.QWidget):
 
         self._timer = QtCore.QTimer(self)
         self._timer.timeout.connect(lambda: self.send_signal(mode=mode, pause=True)) 
-        self._timer.start(self._config['expinsp_setinterval'])
+        self._timer.start(self._config['expinsp_setinterval'] * 1000)
 
 
     def paused_released(self, mode):

--- a/gui/menu/menu.py
+++ b/gui/menu/menu.py
@@ -42,7 +42,7 @@ class Menu(QtWidgets.QWidget):
 
 
         self._timer = QtCore.QTimer(self)
-        self._timer.timeout.connect(lambda: self.send_signal(mode)) 
+        self._timer.timeout.connect(lambda: self.send_signal(mode=mode, pause=True)) 
         self._timer.start(self._config['expinsp_setinterval'])
 
 
@@ -59,13 +59,15 @@ class Menu(QtWidgets.QWidget):
         if hasattr(self, '_timer'):
             self._timer.stop()
 
+        self.send_signal(mode=mode, pause=False)
 
-    def send_signal(self, mode):
+
+    def send_signal(self, mode, pause):
         '''
         Sends signal the appropriate signal the ESP
         to pause inpiration or expiration. 
         '''
-        if not self._data_h.set_data(mode, 1):
+        if not self._data_h.set_data(mode, int(pause)):
             msg = MessageBox()
             fn = msg.critical("Critical",
                               "Severe hardware communication error",

--- a/gui/menu/menu.py
+++ b/gui/menu/menu.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from PyQt5 import QtWidgets, uic
-from PyQt5 import QtGui
+from PyQt5 import QtGui, QtCore
+from messagebox import MessageBox
 
 class Menu(QtWidgets.QWidget):
     def __init__(self, *args):
@@ -11,4 +12,59 @@ class Menu(QtWidgets.QWidget):
         """
         super(Menu, self).__init__(*args)
         uic.loadUi("menu/menu.ui", self)
+
+        self._configured = False
+
+        self.button_expause.pressed.connect(lambda: self.paused_pressed('pause_exhale'))
+        self.button_expause.released.connect(lambda: self.paused_released('pause_exhale'))
+
+        self.button_inspause.pressed.connect(lambda: self.paused_pressed('pause_inhale'))
+        self.button_inspause.released.connect(lambda: self.paused_released('pause_inhale'))
+
+
+    def connect_datahandler_config(self, data_h, config):
+        '''
+        '''
+        self._configured = True
+        self._data_h = data_h
+        self._config = config
+
+    def paused_pressed(self, mode):
+        '''
+        '''
+        if not self._configured:
+            raise Exception('Need to call connect_config_esp first.')
+        if mode not in ['pause_exhale', 'pause_inhale']:
+            raise Exception('Can only call paused_pressed with pause_exhale or pause_inhale.')
+
+
+        self._timer = QtCore.QTimer(self)
+        self._timer.timeout.connect(lambda: self.send_signal(mode)) 
+        self._timer.start(self._config['expinsp_setinterval'])
+
+        print('hi!')
+
+    def paused_released(self, mode):
+        '''
+        '''
+        if not self._configured:
+            raise Exception('Need to call connect_config_esp first.')
+        if mode not in ['pause_exhale', 'pause_inhale']:
+            raise Exception('Can only call paused_pressed with pause_exhale or pause_inhale.')
+
+        if hasattr(self, '_timer'):
+            self._timer.stop()
+
+
+    def send_signal(self, mode):
+        '''
+        '''
+        if not self._data_h.set_data(mode, 1):
+            msg = MessageBox()
+            fn = msg.critical("Critical",
+                              "Severe hardware communication error",
+                              "Cannot pause inspiration/expiration.", 
+                              "Communication error",
+                              { msg.Ok: lambda: self.paused_released(mode) })
+            fn()
 


### PR DESCRIPTION
- Fixes #78.
- The "pause inspiration" and "pause expiration" buttons are connected to the appropriate worker function.
- When pressed, a signal `set pause_inhale 1` or `set pause_exhale 1` is sent to the ESP every 100 ms (configurable via yaml param `expinsp_setinterval`). This is done via a QTimer.
- When the button is released, the QTimer stops.
- If we cannot communicate to the ESP, a critical box is raised, with the only option "Ok".