### PR TITLE
Alarms

### DIFF
--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -2,7 +2,7 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 from messagebox import MessageBox
-from communication.esp32serial import ESP32Alarm
+from communication.esp32serial import ESP32Alarm, ESP32Warning
 
 
 class AlarmHandler:
@@ -12,9 +12,10 @@ class AlarmHandler:
         self._esp32 = esp32
 
         self._alarm_raised = False
+        self._warning_raised = False
 
-
-        self._msg = MessageBox()
+        self._msg_err = MessageBox()
+        self._msg_war = MessageBox()
 
         self._alarm_timer = QtCore.QTimer()
         self._alarm_timer.timeout.connect(self.handle_alarms)
@@ -24,6 +25,9 @@ class AlarmHandler:
 
     def handle_alarms(self):
 
+        #
+        # ALARMS
+        #
         esp32alarm = self._esp32.get_alarms()
         print('esp32alarm', esp32alarm)	
 
@@ -32,25 +36,58 @@ class AlarmHandler:
 
             if not self._alarm_raised:
                 self._alarm_raised = True
-                self._msg.critical("ALARM",
+                self._msg_err.critical("ALARM",
                              " - ".join(errors),
                              "\n".join(errors), 
                              "Alarm received.",
-                             { self._msg.Ok: lambda: self.ok_worker,
-                               self._msg.Abort: lambda: None},
+                             { self._msg_err.Ok: lambda: self.ok_worker('alarm'),
+                               self._msg_err.Abort: lambda: None},
                              do_not_block=True)
-                self._msg.open()
+                self._msg_err.open()
             else:
-                self._msg.setInformativeText(" - ".join(errors))
-                self._msg.setDetailedText("\n".join(errors))
+                self._msg_err.setInformativeText(" - ".join(errors))
+                self._msg_err.setDetailedText("\n".join(errors))
 
-    def ok_worker(self, btn):
 
-        self._alarm_raised = False
+        #
+        # WARNINGS
+        #
+        esp32warnings = self._esp32.get_warnings()
+        print('esp32warnings', esp32warnings) 
+
+        if esp32warnings:
+            errors = esp32warnings.strerror_all()
+
+            if not self._warning_raised:
+                self._warning_raised = True
+                self._msg_war.warning("WARNING",
+                             " - ".join(errors),
+                             "\n".join(errors), 
+                             "Alarm received.",
+                             { self._msg_war.Ok: lambda: self.ok_worker('warning'),
+                               self._msg_war.Abort: lambda: None},
+                             do_not_block=True)
+                self._msg_war.open()
+            else:
+                self._msg_war.setInformativeText(" - ".join(errors))
+                self._msg_war.setDetailedText("\n".join(errors))
+
+    def ok_worker(self, mode):
+
+        if mode not in ['alarm', 'warning']:
+            raise Exception('mode must be alarm or warning.')
+
+        if mode == 'alarm':
+            self._alarm_raised = False
+        else:
+            self._warning_raised = False
 
         # Reset the alarms in the ESP
         try:
-            self._esp32.reset_alarms()
+            if mode == 'alarm':
+                self._esp32.reset_alarms()
+            else:
+                self._esp32.reset_warnings()
         except Exception as error:
             msg = MessageBox()
             fn = msg.critical("Critical",

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -47,12 +47,25 @@ class AlarmHandler:
         errors.
         '''
 
+        # Retrieve alarms and warnings from the ESP
+        try:
+            esp32alarm = self._esp32.get_alarms()
+            esp32warning = self._esp32.get_warnings()
+        except Exception as error:
+            err_msg = "Severe hardware communication error. "
+            err_msg += "Cannot retrieve alarm and warning statuses from hardware."
+            msg = MessageBox()
+            fn = msg.critical("Critical",
+                              err_msg,
+                              str(error), 
+                              "Communication error",
+                              { msg.Retry: lambda: None,
+                                msg.Abort: lambda: None })
+            fn()
+
         #
         # ALARMS
         #
-        esp32alarm = self._esp32.get_alarms()
-        print('esp32alarm', esp32alarm)	
-
         if esp32alarm:
             errors = esp32alarm.strerror_all()
             errors_full = esp32alarm.strerror_all(append_err_no=True)
@@ -77,9 +90,6 @@ class AlarmHandler:
         # 
         # WARNINGS
         # 
-        esp32warning = self._esp32.get_warnings()
-        print('esp32warnings', esp32warning) 
-
         if esp32warning:
             errors = esp32warning.strerror_all()
             errors_full = esp32warning.strerror_all(append_err_no=True)
@@ -132,7 +142,8 @@ class AlarmHandler:
                               "Severe hardware communication error",
                               str(error), 
                               "Communication error",
-                              { msg.Ok: lambda: None })
+                              { msg.Retry: lambda: self.ok_worker(mode),
+                                msg.Abort: lambda: None })
             fn()
         
 

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -33,12 +33,13 @@ class AlarmHandler:
 
         if esp32alarm:
             errors = esp32alarm.strerror_all()
+            errors_full = esp32alarm.strerror_all(append_err_no=True)
 
             if not self._alarm_raised:
                 self._alarm_raised = True
                 self._msg_err.critical("ALARM",
                              " - ".join(errors),
-                             "\n".join(errors), 
+                             "\n".join(errors_full), 
                              "Alarm received.",
                              { self._msg_err.Ok: lambda: self.ok_worker('alarm'),
                                self._msg_err.Abort: lambda: None},
@@ -46,23 +47,26 @@ class AlarmHandler:
                 self._msg_err.open()
             else:
                 self._msg_err.setInformativeText(" - ".join(errors))
-                self._msg_err.setDetailedText("\n".join(errors))
+                self._msg_err.setDetailedText("\n".join(errors_full))
+                self._msg_err.raise_()
+                self._msg_err.setActiveWindow()
 
 
-        #
+        # 
         # WARNINGS
-        #
-        esp32warnings = self._esp32.get_warnings()
-        print('esp32warnings', esp32warnings) 
+        # 
+        esp32warning = self._esp32.get_warnings()
+        print('esp32warnings', esp32warning) 
 
-        if esp32warnings:
-            errors = esp32warnings.strerror_all()
+        if esp32warning:
+            errors = esp32warning.strerror_all()
+            errors_full = esp32warning.strerror_all(append_err_no=True)
 
             if not self._warning_raised:
                 self._warning_raised = True
                 self._msg_war.warning("WARNING",
                              " - ".join(errors),
-                             "\n".join(errors), 
+                             "\n".join(errors_full), 
                              "Alarm received.",
                              { self._msg_war.Ok: lambda: self.ok_worker('warning'),
                                self._msg_war.Abort: lambda: None},
@@ -70,7 +74,9 @@ class AlarmHandler:
                 self._msg_war.open()
             else:
                 self._msg_war.setInformativeText(" - ".join(errors))
-                self._msg_war.setDetailedText("\n".join(errors))
+                self._msg_war.setDetailedText("\n".join(errors_full))
+                self._msg_war.raise_()
+                self._msg_war.setActiveWindow()
 
     def ok_worker(self, mode):
 
@@ -82,7 +88,7 @@ class AlarmHandler:
         else:
             self._warning_raised = False
 
-        # Reset the alarms in the ESP
+        # Reset the alarms/warnings in the ESP
         try:
             if mode == 'alarm':
                 self._esp32.reset_alarms()

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -31,6 +31,7 @@ class AlarmHandler:
             errors = esp32alarm.strerror_all()
 
             if not self._alarm_raised:
+                self._alarm_raised = True
                 self._msg.critical("ALARM",
                              " - ".join(errors),
                              "\n".join(errors), 
@@ -41,6 +42,7 @@ class AlarmHandler:
                 self._msg.open()
             else:
                 self._msg.setInformativeText(" - ".join(errors))
+                self._msg.setDetailedText("\n".join(errors))
 
     def ok_worker(self, btn):
 

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -1,0 +1,61 @@
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+from messagebox import MessageBox
+from communication.esp32serial import ESP32Alarm
+
+
+class AlarmHandler:
+
+    def __init__(self, config, esp32):
+        self._config = config
+        self._esp32 = esp32
+
+        self._alarm_raised = False
+
+
+        self._msg = MessageBox()
+
+        self._alarm_timer = QtCore.QTimer()
+        self._alarm_timer.timeout.connect(self.handle_alarms)
+        self._alarm_timer.start(config["alarminterval"] * 1000)
+
+
+
+    def handle_alarms(self):
+
+        esp32alarm = self._esp32.get_alarms()
+        print('esp32alarm', esp32alarm)	
+
+        if esp32alarm:
+            errors = esp32alarm.strerror_all()
+
+            if not self._alarm_raised:
+                self._msg.critical("ALARM",
+                             " - ".join(errors),
+                             "\n".join(errors), 
+                             "Alarm received.",
+                             { self._msg.Ok: lambda: self.ok_worker,
+                               self._msg.Abort: lambda: None},
+                             do_not_block=True)
+                self._msg.open()
+            else:
+                self._msg.setInformativeText(" - ".join(errors))
+
+    def ok_worker(self, btn):
+
+        self._alarm_raised = False
+
+        # Reset the alarms in the ESP
+        try:
+            self._esp32.reset_alarms()
+        except Exception as error:
+            msg = MessageBox()
+            fn = msg.critical("Critical",
+                              "Severe hardware communication error",
+                              str(error), 
+                              "Communication error",
+                              { msg.Ok: lambda: None })
+            fn()
+        
+

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -147,10 +147,23 @@ class AlarmHandler:
                                 msg.Abort: lambda: None })
             fn()
         
+    def code_to_int(self, code):
+        '''
+        From a code to an integer with 
+        the right bit set
+        TODO
+        '''
+        return 1
 
     def raise_alarm(self, code):
-        self._esp32.raise_alarm(ESP32Alarm().code_to_int(code))
+        '''
+        Raises an alarm in the ESP
+        '''
+        self._esp32.raise_alarm(self.code_to_int(code))
 
     def stop_alarm(self, code):
+        '''
+        Stops an alarm in the ESP
+        '''
         self._esp32.reset_alarms()
 

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -6,8 +6,21 @@ from communication.esp32serial import ESP32Alarm, ESP32Warning
 
 
 class AlarmHandler:
+    '''
+    This class starts a QTimer dedicated
+    to checking is there are any errors
+    or warnings coming from ESP32
+    '''
 
     def __init__(self, config, esp32):
+        '''
+        Constructor
+
+        parameters:
+        - config: the dictionary storing the configuration
+        - esp32: the esp32serial object
+        '''
+
         self._config = config
         self._esp32 = esp32
 
@@ -24,6 +37,15 @@ class AlarmHandler:
 
 
     def handle_alarms(self):
+        '''
+        The callback method which is called periodically
+        to check if the ESP raised any alarm or warning.
+        If an alarm or warning is raised, a pop up
+        window appears, showing the list of alarms and
+        warnings. If more alarms or warnings add up, the 
+        window is updated automatically showing the latest
+        errors.
+        '''
 
         #
         # ALARMS
@@ -69,7 +91,7 @@ class AlarmHandler:
                              "\n".join(errors_full), 
                              "Alarm received.",
                              { self._msg_war.Ok: lambda: self.ok_worker('warning'),
-                               self._msg_war.Abort: lambda: None},
+                               self._msg_war.Abort: lambda: None },
                              do_not_block=True)
                 self._msg_war.open()
             else:
@@ -79,6 +101,14 @@ class AlarmHandler:
                 self._msg_war.setActiveWindow()
 
     def ok_worker(self, mode):
+        '''
+        The callback function called when the alarm 
+        or warning pop up window is closed by clicking
+        on the Ok button.
+
+        arguments:
+        - mode: what this is closing, an 'alarm' or a 'warning'
+        '''
 
         if mode not in ['alarm', 'warning']:
             raise Exception('mode must be alarm or warning.')
@@ -89,6 +119,8 @@ class AlarmHandler:
             self._warning_raised = False
 
         # Reset the alarms/warnings in the ESP
+        # If the ESP connection fails at this 
+        # time, raise an error box
         try:
             if mode == 'alarm':
                 self._esp32.reset_alarms()

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -52,6 +52,8 @@ class AlarmHandler:
             esp32alarm = self._esp32.get_alarms()
             esp32warning = self._esp32.get_warnings()
         except Exception as error:
+            esp32alarm = None
+            esp32warning = None
             err_msg = "Severe hardware communication error. "
             err_msg += "Cannot retrieve alarm and warning statuses from hardware."
             msg = MessageBox()

--- a/gui/alarm_handler.py
+++ b/gui/alarm_handler.py
@@ -16,7 +16,7 @@ class AlarmHandler:
         '''
         Constructor
 
-        parameters:
+        arguments:
         - config: the dictionary storing the configuration
         - esp32: the esp32serial object
         '''
@@ -81,10 +81,10 @@ class AlarmHandler:
                              do_not_block=True)
                 self._msg_err.open()
             else:
+                # If the window is already opened, just change the text
                 self._msg_err.setInformativeText(" - ".join(errors))
                 self._msg_err.setDetailedText("\n".join(errors_full))
                 self._msg_err.raise_()
-                self._msg_err.setActiveWindow()
 
 
         # 
@@ -105,10 +105,11 @@ class AlarmHandler:
                              do_not_block=True)
                 self._msg_war.open()
             else:
+                # If the window is already opened, just change the text
                 self._msg_war.setInformativeText(" - ".join(errors))
                 self._msg_war.setDetailedText("\n".join(errors_full))
                 self._msg_war.raise_()
-                self._msg_war.setActiveWindow()
+
 
     def ok_worker(self, mode):
         '''
@@ -146,4 +147,10 @@ class AlarmHandler:
                                 msg.Abort: lambda: None })
             fn()
         
+
+    def raise_alarm(self, code):
+        self._esp32.raise_alarm(ESP32Alarm().code_to_int(code))
+
+    def stop_alarm(self, code):
+        self._esp32.reset_alarms()
 

--- a/gui/communication/__init__.py
+++ b/gui/communication/__init__.py
@@ -1,1 +1,2 @@
+from .esp32alarm import *
 from .esp32serial import *

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -1,34 +1,9 @@
 import copy
 
-class ESP32Alarm:
+class ESP32BaseAlarm:
 
     alarm_to_string = {
-        # From the ESP
-        0: "Gas pressure too low",
-        1: "Gas pressure too high",
-        2: "Internal pressure too low (internal leakage)",
-        3: "Internal pressure too high",
-        4: "Out of battery power",
-        5: "Leakage in gas circuit",
-        6: "Obstruction in idraulic circuit",
-        7: "Partial obstruction in idraulic circuit",
-        # From the GUI
-        8: "Pressure to patient mouth too low",
-        9: "Pressure to patient mouth too high",
-        10: "Inpiratory flux too low",
-        11: "Inpiratory flux too high",
-        12: "Expiratory flux too low",
-        13: "Expiratory flux too high",
-        14: "Tidal volume too low",
-        15: "Tidal volume too high",
-        16: "O2 too low",
-        17: "O2 too high",
-        18: "PEEP too low",
-        19: "PEEP too high",
-        20: "Respiratory rate too low",
-        21: "Respiratory rate too high",
-        
-        31: "System failure",
+        0: "Alarm name",
     }
 
     def __init__(self, number):
@@ -76,3 +51,44 @@ class ESP32Alarm:
             str_error.append(self.strerror(n))
 
         return str_error
+
+
+
+class ESP32Alarm(ESP32BaseAlarm):
+
+    alarm_to_string = {
+        # From the ESP
+        0: "Gas pressure too low",
+        1: "Gas pressure too high",
+        2: "Internal pressure too low (internal leakage)",
+        3: "Internal pressure too high",
+        4: "Out of battery power",
+        5: "Leakage in gas circuit",
+        6: "Obstruction in idraulic circuit",
+        7: "Partial obstruction in idraulic circuit",
+        # From the GUI
+        8: "Pressure to patient mouth too low",
+        9: "Pressure to patient mouth too high",
+        10: "Inpiratory flux too low",
+        11: "Inpiratory flux too high",
+        12: "Expiratory flux too low",
+        13: "Expiratory flux too high",
+        14: "Tidal volume too low",
+        15: "Tidal volume too high",
+        16: "O2 too low",
+        17: "O2 too high",
+        18: "PEEP too low",
+        19: "PEEP too high",
+        20: "Respiratory rate too low",
+        21: "Respiratory rate too high",
+        
+        31: "System failure",
+    }
+
+class ESP32Warning(ESP32BaseAlarm):
+
+    alarm_to_string = {
+        # From the ESP
+        0: "Oxygen sensor requires calibration",
+        1: "Disconnected from power outlet",
+    }

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -1,5 +1,3 @@
-import copy
-
 class ESP32BaseAlarm:
     '''
     The base ESP Alarm Class
@@ -28,17 +26,8 @@ class ESP32BaseAlarm:
         '''
         Unpacks the number obtained from the ESP
         '''
-        self.alarms = []
 
-        n = copy.copy(self.number)
-
-        bit_pos = 0
-        while n:
-            if n & 1:
-                self.alarms.append(bit_pos)
-
-            bit_pos += 1
-            n >>= 1
+        self.alarms = list(filter(lambda x: x, [ self.number & (1<<test) for test in range(32)]))
 
         print('Found alarms', self.alarms)
 
@@ -115,7 +104,7 @@ class ESP32Alarm(ESP32BaseAlarm):
         19: "PEEP too high",
         20: "Respiratory rate too low",
         21: "Respiratory rate too high",
-        
+
         31: "System failure",
     }
 

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -1,0 +1,72 @@
+
+class ESP32Alarm:
+
+    alarm_to_string = {
+        # From the ESP
+        0: "Gas pressure too low",
+        1: "Gas pressure too high",
+        2: "Internal pressure too low (internal leakage)",
+        3: "Internal pressure too high",
+        4: "Out of battery power",
+        5: "Leakage in gas circuit",
+        6: "Obstruction in idraulic circuit",
+        7: "Partial obstruction in idraulic circuit",
+        # From the GUI
+        8: "Pressure to patient mouth too low",
+        9: "Pressure to patient mouth too high",
+        10: "Inpiratory flux too low",
+        11: "Inpiratory flux too high",
+        12: "Expiratory flux too low",
+        13: "Expiratory flux too high",
+        14: "Tidal volume too low",
+        15: "Tidal volume too high",
+        16: "O2 too low",
+        17: "O2 too high",
+        18: "PEEP too low",
+        19: "PEEP too high",
+        20: "Respiratory rate too low",
+        21: "Respiratory rate too high",
+        
+        31: "System failure",
+    }
+
+    def __init__(self, number):
+        self.number = number
+
+    def __bool__(self):
+        print('in __bool__:', self.number)
+        return self.number != 0
+
+    def unpack(self):
+        bit_pos = 0
+        self.alarms = []
+
+        while self.number:
+            if self.number & 1:
+                self.alarms.append(bit_pos)
+
+            bit_pos += 1
+            self.number >>= 1
+
+        print('Found alarms', self.alarms)
+
+        return self.alarms
+
+    def strerror(self, n):
+        if not hasattr(self, 'alarms'):
+            self.unpack()
+
+        if n in self.alarm_to_string:
+            return self.alarm_to_string[n]
+        else:
+            return 'Unknown error'
+
+    def strerror_all(self):
+        if not hasattr(self, 'alarms'):
+            self.unpack()
+
+        str_error = []
+        for n in self.alarms:
+            str_error.append(self.strerror(n))
+
+        return str_error

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -19,7 +19,6 @@ class ESP32BaseAlarm:
         self.number = number
 
     def __bool__(self):
-        print('in __bool__:', self.number)
         return self.number != 0
 
     def __str__(self):

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -1,12 +1,21 @@
 import copy
 
 class ESP32BaseAlarm:
+    '''
+    The base ESP Alarm Class
+    '''
 
     alarm_to_string = {
         0: "Alarm name",
     }
 
     def __init__(self, number):
+        '''
+        Constructor
+
+        arguments:
+        - the number obtained from the ESP
+        '''
         self.number = number
 
     def __bool__(self):
@@ -17,11 +26,14 @@ class ESP32BaseAlarm:
         return 'All alarms: ' + ' - '.join(self.strerror_all())
 
     def unpack(self):
-        bit_pos = 0
+        '''
+        Unpacks the number obtained from the ESP
+        '''
         self.alarms = []
 
         n = copy.copy(self.number)
 
+        bit_pos = 0
         while n:
             if n & 1:
                 self.alarms.append(bit_pos)
@@ -33,7 +45,23 @@ class ESP32BaseAlarm:
 
         return self.alarms
 
+    def code_to_int(self):
+        '''
+        From a code to an integer with 
+        the right bit set
+        TODO
+        '''
+        return 1
+
+
     def strerror(self, n):
+        '''
+        Returns a string with the error
+        specified by n
+
+        arguments:
+        - n: the error number (unpacked)
+        '''
         if not hasattr(self, 'alarms'):
             self.unpack()
 
@@ -43,6 +71,13 @@ class ESP32BaseAlarm:
             return 'Unknown error'
 
     def strerror_all(self, append_err_no=False):
+        '''
+        Same as strerror, but returns a list
+        in case of multiple errors
+
+        arguments:
+        - append_err_no: if True, also adds the err number
+        '''
         if not hasattr(self, 'alarms'):
             self.unpack()
 
@@ -50,7 +85,7 @@ class ESP32BaseAlarm:
         for n in self.alarms:
 
             s = self.strerror(n)
-            
+
             if append_err_no:
                 s += ' (code: '
                 s += str(n)

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -1,3 +1,4 @@
+import copy
 
 class ESP32Alarm:
 
@@ -37,16 +38,21 @@ class ESP32Alarm:
         print('in __bool__:', self.number)
         return self.number != 0
 
+    def __str__(self):
+        return 'All alarms: ' + ' - '.join(self.strerror_all())
+
     def unpack(self):
         bit_pos = 0
         self.alarms = []
 
-        while self.number:
-            if self.number & 1:
+        n = copy.copy(self.number)
+
+        while n:
+            if n & 1:
                 self.alarms.append(bit_pos)
 
             bit_pos += 1
-            self.number >>= 1
+            n >>= 1
 
         print('Found alarms', self.alarms)
 

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -42,13 +42,21 @@ class ESP32BaseAlarm:
         else:
             return 'Unknown error'
 
-    def strerror_all(self):
+    def strerror_all(self, append_err_no=False):
         if not hasattr(self, 'alarms'):
             self.unpack()
 
         str_error = []
         for n in self.alarms:
-            str_error.append(self.strerror(n))
+
+            s = self.strerror(n)
+            
+            if append_err_no:
+                s += ' (code: '
+                s += str(n)
+                s += ')'
+
+            str_error.append(s)
 
         return str_error
 

--- a/gui/communication/esp32alarm.py
+++ b/gui/communication/esp32alarm.py
@@ -45,14 +45,6 @@ class ESP32BaseAlarm:
 
         return self.alarms
 
-    def code_to_int(self):
-        '''
-        From a code to an integer with 
-        the right bit set
-        TODO
-        '''
-        return 1
-
 
     def strerror(self, n):
         '''

--- a/gui/communication/esp32serial.py
+++ b/gui/communication/esp32serial.py
@@ -6,7 +6,7 @@ from threading import Lock
 import serial # pySerial
 
 
-__all__ = ("ESP32Serial", "ESP32Exception")
+__all__ = ("ESP32Serial", "ESP32Exception", "ESP32Alarm")
 
 
 class ESP32Exception(Exception):
@@ -30,6 +30,22 @@ class ESP32Exception(Exception):
 
         super(ESP32Exception, self).__init__(
                 "ERROR in %s: line: '%s'; output: %s" % (verb, line, output))
+
+
+class ESP32Alarm:
+
+    def __init__(self, number):
+        self.number = number
+
+    def __bool__(self):
+        return True
+
+    def unpack(self):
+        return
+
+    def strerror(self, n):
+        return 'An error'
+
 
 
 class ESP32Serial:

--- a/gui/communication/esp32serial.py
+++ b/gui/communication/esp32serial.py
@@ -35,6 +35,7 @@ class ESP32Exception(Exception):
 class ESP32Alarm:
 
     alarm_to_string = {
+        # From the ESP
         0: "Gas pressure too low",
         1: "Gas pressure too high",
         2: "Internal pressure too low (internal leakage)",
@@ -43,6 +44,22 @@ class ESP32Alarm:
         5: "Leakage in gas circuit",
         6: "Obstruction in idraulic circuit",
         7: "Partial obstruction in idraulic circuit",
+        # From the GUI
+        8: "Pressure to patient mouth too low",
+        9: "Pressure to patient mouth too high",
+        10: "Inpiratory flux too low",
+        11: "Inpiratory flux too high",
+        12: "Expiratory flux too low",
+        13: "Expiratory flux too high",
+        14: "Tidal volume too low",
+        15: "Tidal volume too high",
+        16: "O2 too low",
+        17: "O2 too high",
+        18: "PEEP too low",
+        19: "PEEP too high",
+        20: "Respiratory rate too low",
+        21: "Respiratory rate too high",
+        
         31: "System failure",
     }
 

--- a/gui/communication/esp32serial.py
+++ b/gui/communication/esp32serial.py
@@ -4,9 +4,9 @@ Library to interface with the ESP32
 
 from threading import Lock
 import serial # pySerial
+from . import ESP32Alarm
 
-
-__all__ = ("ESP32Serial", "ESP32Exception", "ESP32Alarm")
+__all__ = ("ESP32Serial", "ESP32Exception")
 
 
 class ESP32Exception(Exception):
@@ -30,78 +30,6 @@ class ESP32Exception(Exception):
 
         super(ESP32Exception, self).__init__(
                 "ERROR in %s: line: '%s'; output: %s" % (verb, line, output))
-
-
-class ESP32Alarm:
-
-    alarm_to_string = {
-        # From the ESP
-        0: "Gas pressure too low",
-        1: "Gas pressure too high",
-        2: "Internal pressure too low (internal leakage)",
-        3: "Internal pressure too high",
-        4: "Out of battery power",
-        5: "Leakage in gas circuit",
-        6: "Obstruction in idraulic circuit",
-        7: "Partial obstruction in idraulic circuit",
-        # From the GUI
-        8: "Pressure to patient mouth too low",
-        9: "Pressure to patient mouth too high",
-        10: "Inpiratory flux too low",
-        11: "Inpiratory flux too high",
-        12: "Expiratory flux too low",
-        13: "Expiratory flux too high",
-        14: "Tidal volume too low",
-        15: "Tidal volume too high",
-        16: "O2 too low",
-        17: "O2 too high",
-        18: "PEEP too low",
-        19: "PEEP too high",
-        20: "Respiratory rate too low",
-        21: "Respiratory rate too high",
-        
-        31: "System failure",
-    }
-
-    def __init__(self, number):
-        self.number = number
-
-    def __bool__(self):
-        return self.number != 0
-
-    def unpack(self):
-        bit_pos = 0
-        self.alarms = []
-
-        while self.number:
-            if self.number & 1:
-                self.alarms.append(bit_pos)
-
-            bit_pos += 1
-            self.number >>= 1
-
-        print('Found alarms', self.alarms)
-
-        return self.alarms
-
-    def strerror(self, n):
-        if not hasattr(self, 'alarms'):
-            self.unpack()
-
-        if n in self.alarm_to_string:
-            return self.alarm_to_string[n]
-        else:
-            return 'Unknown error'
-
-    def strerror_all(self):
-        if not hasattr(self, 'alarms'):
-            self.unpack()
-
-        str_error = []
-        for n in self.alarms:
-            str_error.append(self.strerror(n))
-
-        return str_error
 
 
 

--- a/gui/communication/esp32serial.py
+++ b/gui/communication/esp32serial.py
@@ -4,7 +4,7 @@ Library to interface with the ESP32
 
 from threading import Lock
 import serial # pySerial
-from . import ESP32Alarm
+from . import ESP32Alarm, ESP32Warning
 
 __all__ = ("ESP32Serial", "ESP32Exception")
 
@@ -210,7 +210,7 @@ class ESP32Serial:
         returns: a ESP32Alarm instance describing the possible warnings.
         """
 
-        return ESP32Alarm(int(self.get("warning")))
+        return ESP32Warning(int(self.get("warning")))
 
     def reset_alarms(self):
         """

--- a/gui/communication/esp32serial.py
+++ b/gui/communication/esp32serial.py
@@ -221,6 +221,15 @@ class ESP32Serial:
 
         return self.set("alarm", 0)
 
+    def reset_warnings(self):
+        """
+        Reset all the raised warnings in ESP32
+
+        returns: an "OK" string in case of success.
+        """
+
+        return self.set("warning", 0)
+
     def raise_alarm(self, alarm_type):
         """
         Raises an alarm in ESP32

--- a/gui/communication/esp32serial.py
+++ b/gui/communication/esp32serial.py
@@ -207,7 +207,7 @@ class ESP32Serial:
         """
         Get the warnings from the ESP32
 
-        returns: a ESP32Alarm instance describing the possible warnings.
+        returns: a ESP32Warning instance describing the possible warnings.
         """
 
         return ESP32Warning(int(self.get("warning")))

--- a/gui/communication/esp32serial.py
+++ b/gui/communication/esp32serial.py
@@ -188,3 +188,42 @@ class ESP32Serial:
                 except Exception as exc:
                     print("ERROR: get failing: %s %s" % (result.decode(), str(exc)))
             raise ESP32Exception("get", "get all", result.decode())
+
+    def get_alarms(self):
+        """
+        Get the alarms from the ESP32
+
+        returns: a ESP32Alarm instance describing the possible alarms.
+        """
+
+        return ESP32Alarm(int(self.get("alarm")))
+
+    def get_warnings(self):
+        """
+        Get the warnings from the ESP32
+
+        returns: a ESP32Alarm instance describing the possible warnings.
+        """
+
+        return ESP32Alarm(int(self.get("warning")))
+
+    def reset_alarms(self):
+        """
+        Reset all the raised alarms in ESP32
+
+        returns: an "OK" string in case of success.
+        """
+
+        return self.set("alarm", 0)
+
+    def raise_alarm(self, alarm_type):
+        """
+        Raises an alarm in ESP32
+
+        arguments:
+        - alarm_type      an integer representing the alarm type
+
+        returns: an "OK" string in case of success.
+        """
+
+        return self.set("alarm", alarm_type)

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -7,7 +7,7 @@ as needed.
 """
 
 from threading import Lock
-import sys, random
+import random
 from communication.peep import peep
 from . import ESP32Alarm, ESP32Warning
 
@@ -64,7 +64,7 @@ class FakeESP32Serial:
 
             if name == 'alarm' or name == 'warning':
                 if random.uniform(0, 1) < 0.1:
-                    retval = int(random.uniform(0, sys.maxsize))
+                    retval = int(random.uniform(0, 2147483647))
                     print(f'**************************************************** {name} SIMULATION, retval', retval)
                 else:
                     retval = 0

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -9,7 +9,7 @@ as needed.
 from threading import Lock
 import random
 from communication.peep import peep
-from . import ESP32Alarm
+from . import ESP32Alarm, ESP32Warnings
 
 class FakeESP32Serial:
     peep = peep()
@@ -112,7 +112,7 @@ class FakeESP32Serial:
         returns: a ESP32Alarm instance describing the possible warnings.
         """
 
-        return ESP32Alarm(int(self.get("warning")))
+        return ESP32Warnings(int(self.get("warning")))
 
     def reset_alarms(self):
         """

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -14,7 +14,7 @@ class FakeESP32Serial:
     peep = peep()
     def __init__(self):
         self.lock = Lock()
-        self.set_params = {}
+        self.set_params = {"alarm": 0, "warning": 0}
         self.random_params = ["pressure", "flow", "o2", "bpm", "tidal",
                               "peep", "temperature", "power_mode",
                               "battery" ]
@@ -88,3 +88,42 @@ class FakeESP32Serial:
                     "temperature": random.uniform(10, 50),
                     "power_mode":  int(random.uniform(0, 1.5)),
                     "battery":     random.uniform(1, 100)}
+
+    def get_alarms(self):
+        """
+        Get the alarms from the ESP32
+
+        returns: a ESP32Alarm instance describing the possible alarms.
+        """
+
+        return ESP32Alarm(int(self.get("alarm")))
+
+    def get_warnings(self):
+        """
+        Get the warnings from the ESP32
+
+        returns: a ESP32Alarm instance describing the possible warnings.
+        """
+
+        return ESP32Alarm(int(self.get("warning")))
+
+    def reset_alarms(self):
+        """
+        Reset all the raised alarms in ESP32
+
+        returns: an "OK" string in case of success.
+        """
+
+        return self.set("alarm", 0)
+
+    def raise_alarm(self, alarm_type):
+        """
+        Raises an alarm in ESP32
+
+        arguments:
+        - alarm_type      an integer representing the alarm type
+
+        returns: an "OK" string in case of success.
+        """
+
+        return self.set("alarm", alarm_type)

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -123,6 +123,15 @@ class FakeESP32Serial:
 
         return self.set("alarm", 0)
 
+    def reset_warnings(self):
+        """
+        Reset all the raised warnings in ESP32
+
+        returns: an "OK" string in case of success.
+        """
+
+        return self.set("warning", 0)
+
     def raise_alarm(self, alarm_type):
         """
         Raises an alarm in ESP32

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -7,7 +7,7 @@ as needed.
 """
 
 from threading import Lock
-import random
+import sys, random
 from communication.peep import peep
 from . import ESP32Alarm, ESP32Warning
 
@@ -64,8 +64,8 @@ class FakeESP32Serial:
 
             if name == 'alarm' or name == 'warning':
                 if random.uniform(0, 1) < 0.1:
-                    retval = int(random.uniform(0, 32))
-                    print('**************************************************** ALARM SIMULATION, retval', retval)
+                    retval = int(random.uniform(0, sys.maxsize))
+                    print(f'**************************************************** {name} SIMULATION, retval', retval)
                 else:
                     retval = 0
             elif name in self.set_params:

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -65,7 +65,7 @@ class FakeESP32Serial:
             if name == 'alarm' or name == 'warning':
                 if random.uniform(0, 1) < 0.1:
                     retval = int(random.uniform(0, 2147483647))
-                    print(f'**************************************************** {name} SIMULATION, retval', retval)
+                    print('**************************************************** ALARM/WARINING SIMULATION, retval', retval)
                 else:
                     retval = 0
             elif name in self.set_params:

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -9,6 +9,7 @@ as needed.
 from threading import Lock
 import random
 from communication.peep import peep
+from . import ESP32Alarm
 
 class FakeESP32Serial:
     peep = peep()
@@ -61,7 +62,13 @@ class FakeESP32Serial:
         with self.lock:
             retval = 0
 
-            if name in self.set_params:
+            if name == 'alarm' or name == 'warning':
+                if random.uniform(0, 1) < 0.1:
+                    retval = int(random.uniform(0, 32))
+                    print('**************************************************** ALARM SIMULATION, retval', retval)
+                else:
+                    retval = 0
+            elif name in self.set_params:
                 retval = self.set_params[name]
             elif name in self.random_params:
                 retval = random.uniform(10, 100)

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -9,7 +9,7 @@ as needed.
 from threading import Lock
 import random
 from communication.peep import peep
-from . import ESP32Alarm, ESP32Warnings
+from . import ESP32Alarm, ESP32Warning
 
 class FakeESP32Serial:
     peep = peep()
@@ -109,10 +109,10 @@ class FakeESP32Serial:
         """
         Get the warnings from the ESP32
 
-        returns: a ESP32Alarm instance describing the possible warnings.
+        returns: a ESP32Warning instance describing the possible warnings.
         """
 
-        return ESP32Warnings(int(self.get("warning")))
+        return ESP32Warning(int(self.get("warning")))
 
     def reset_alarms(self):
         """

--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -56,9 +56,8 @@ class DataFiller():
         
         # Set the Y axis
         y_axis_label = self._config[monitor_name]['name']
-        y_axis_label += ' ['
-        y_axis_label += self._config[monitor_name]['units'].get(name, '')
-        y_axis_label += ']'
+        y_axis_label += ' '
+        y_axis_label += self._config[monitor_name]['units']
         plot.setLabel(axis='left', text=y_axis_label)
 
         # Set the X axis

--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -57,7 +57,7 @@ class DataFiller():
         # Set the Y axis
         y_axis_label = self._config[monitor_name]['name']
         y_axis_label += ' ['
-        y_axis_label += self._config['var_units'].get(name, '')
+        y_axis_label += self._config[monitor_name]['units'].get(name, '')
         y_axis_label += ']'
         plot.setLabel(axis='left', text=y_axis_label)
 

--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -4,6 +4,9 @@ port: '/dev/cu.usbmodem143301'
 # watchdog reset interval time in seconds
 wdinterval: 1
 
+# Time interval used to check for alarms
+alarminterval: 1
+
 # Number of samples to display in the graphs:
 nsamples: 100
 
@@ -54,14 +57,6 @@ show_x_axis_ticks: True
 # Toggles between scrolling plots and looping plots
 use_looping_plots: False
 
-# The units used for each variable:
-var_units: 
-    pressure: 'mbar'
-    flow: 'lpm'
-    o2: '%'
-    bpm: 'Hz'
-    volume: 'ml'
-
 # Control Start/Stop Auto/Man behavior
 start_mode_timeout: 2000 # [ms] between pressing Start and allowing Stop (max 3000)
 
@@ -80,6 +75,8 @@ monitor_top:
     color: "rgb(255,255,0)"
     alarmcolor: "red"
     plot_var: pressure
+    alarm_min_code: 8
+    alarm_max_code: 9
 
 monitor_mid: 
     name: "V<sub>tidal</sub>"
@@ -92,6 +89,8 @@ monitor_mid:
     color: "rgb(50,205,50)"
     alarmcolor: "red"
     plot_var: tidal
+    alarm_min_code: 14
+    alarm_max_code: 15
 
 monitor_bot: 
     name: "MVe"
@@ -104,6 +103,8 @@ monitor_bot:
     color: "rgb(0,255,255)"
     alarmcolor: "red"
     plot_var: flow
+    alarm_min_code: 11
+    alarm_max_code: 12
 
 
 

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -15,6 +15,7 @@ from monitor.monitor import Monitor
 from data_filler import DataFiller
 from data_handler import DataHandler
 from start_stop_worker import StartStopWorker
+from alarm_handler import AlarmHandler
 
 import pyqtgraph as pg
 import sys
@@ -41,6 +42,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.config = config
         self.esp32 = esp32
+
+        '''
+        Start the alarm handler, which will check for ESP alarms
+        '''
+        self.alarm_h = AlarmHandler(self.config, self.esp32)
+
 
         '''
         Get the toppane and child pages
@@ -223,7 +230,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 alarmcolor=entry.get("alarmcolor", monitor_default["alarmcolor"]),
                 color=entry.get("color", monitor_default["color"]),
                 step=entry.get("step", monitor_default["step"]),
-                dec_precision=entry.get("dec_precision", monitor_default["dec_precision"]))
+                dec_precision=entry.get("dec_precision", monitor_default["dec_precision"]),
+                alarm_handler=self.alarm_h)
         return monitor
 
     def open_menu(self):

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -229,7 +229,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Generate monitors and plots
         for name in monitor_names:
-            monitor = Monitor(name, config, self.alarm_h)
+            monitor = Monitor(name, config, self.alarm_h,
+                    self.config[name]["alarm_min_code"],
+                    self.config[name]["alarm_max_code"])
             self.monitors[name] = monitor
             plot = pg.PlotWidget()
             self.plots[name] = plot

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -90,6 +90,8 @@ class MessageBox(QMessageBox):
         self.setStandardButtons(bitmask)
 
         if do_not_block:
+            for btn, callback in callbacks.items():
+                self.button(btn).clicked.connect(callback)
             return True
         else:
             return callbacks[self.exec()]

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -29,7 +29,7 @@ class MessageBox(QMessageBox):
         super(MessageBox, self).__init__()
 
 
-    def _wrapper(self, text, long_text, detail_text, title, icon, callbacks):
+    def _wrapper(self, text, long_text, detail_text, title, icon, callbacks, do_not_block=False):
         """
         Wrapper function to implement the message box
 
@@ -48,6 +48,9 @@ class MessageBox(QMessageBox):
                             MessageBox.Yes, MessageBox.No, MessageBox.Abort,
                             MessageBox.Retry, and MessageBox.Ignore
                         value is a user-defined function object
+        - do_not_block  bool: By default, a QMessage blocks further
+                        actions until the QMessage is closed. If you don't
+                        want to block further actions, set this to True
 
         returns the function object corresponding to the clicked button.
         """
@@ -86,7 +89,10 @@ class MessageBox(QMessageBox):
         self.setStyleSheet(button_style);
         self.setStandardButtons(bitmask)
 
-        return callbacks[self.exec()]
+        if do_not_block:
+            return callbacks[self.open()]
+        else:
+            return callbacks[self.exec()]
 
     def question(self, text, long_text, detail_text, title, callbacks):
         """

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -90,11 +90,11 @@ class MessageBox(QMessageBox):
         self.setStandardButtons(bitmask)
 
         if do_not_block:
-            return callbacks[self.open()]
+            return True
         else:
             return callbacks[self.exec()]
 
-    def question(self, text, long_text, detail_text, title, callbacks):
+    def question(self, text, long_text, detail_text, title, callbacks, do_not_block=False):
         """
         Display a question message window
 
@@ -110,13 +110,16 @@ class MessageBox(QMessageBox):
                             MessageBox.Yes, MessageBox.No, MessageBox.Abort,
                             MessageBox.Retry, and MessageBox.Ignore
                         value is a user-defined function object
+        - do_not_block  bool: By default, a QMessage blocks further
+                        actions until the QMessage is closed. If you don't
+                        want to block further actions, set this to True
 
         returns the function object corresponding to the clicked button.
         """
         return self._wrapper(text, long_text, detail_text, title,
-                             self.Question, callbacks)
+                             self.Question, callbacks, do_not_block)
 
-    def critical(self, text, long_text, detail_text, title, callbacks):
+    def critical(self, text, long_text, detail_text, title, callbacks, do_not_block=False):
         """
         Display a critical error window
 
@@ -132,15 +135,18 @@ class MessageBox(QMessageBox):
                             MessageBox.Yes, MessageBox.No, MessageBox.Abort,
                             MessageBox.Retry, and MessageBox.Ignore
                         value is a user-defined function object
+        - do_not_block  bool: By default, a QMessage blocks further
+                        actions until the QMessage is closed. If you don't
+                        want to block further actions, set this to True
 
         returns the function object corresponding to the clicked button.
         """
 
         text = "<font color='#ff0000'>%s</font>" % text
         return self._wrapper(text, long_text, detail_text, title,
-                             self.Critical, callbacks)
+                             self.Critical, callbacks, do_not_block)
 
-    def warning(self, text, long_text, detail_text, title, callbacks):
+    def warning(self, text, long_text, detail_text, title, callbacks, do_not_block=False):
         """
         Display a warning message window
 
@@ -156,11 +162,14 @@ class MessageBox(QMessageBox):
                             MessageBox.Yes, MessageBox.No, MessageBox.Abort,
                             MessageBox.Retry, and MessageBox.Ignore
                         value is a user-defined function object
+        - do_not_block  bool: By default, a QMessage blocks further
+                        actions until the QMessage is closed. If you don't
+                        want to block further actions, set this to True
 
         returns the function object corresponding to the clicked button.
         """
 
         return self._wrapper(text, long_text, detail_text, title,
-                             self.Warning, callbacks)
+                             self.Warning, callbacks, do_not_block)
 
 

--- a/gui/messagebox.py
+++ b/gui/messagebox.py
@@ -90,6 +90,7 @@ class MessageBox(QMessageBox):
         self.setStandardButtons(bitmask)
 
         if do_not_block:
+            # Connect buttons to the appropriate callbacks in this case
             for btn, callback in callbacks.items():
                 self.button(btn).clicked.connect(callback)
             return True
@@ -112,8 +113,8 @@ class MessageBox(QMessageBox):
                             MessageBox.Yes, MessageBox.No, MessageBox.Abort,
                             MessageBox.Retry, and MessageBox.Ignore
                         value is a user-defined function object
-        - do_not_block  bool: By default, a QMessage blocks further
-                        actions until the QMessage is closed. If you don't
+        - do_not_block  bool: By default, a QMessageBox blocks further
+                        actions until the QMessageBox is closed. If you don't
                         want to block further actions, set this to True
 
         returns the function object corresponding to the clicked button.
@@ -137,8 +138,8 @@ class MessageBox(QMessageBox):
                             MessageBox.Yes, MessageBox.No, MessageBox.Abort,
                             MessageBox.Retry, and MessageBox.Ignore
                         value is a user-defined function object
-        - do_not_block  bool: By default, a QMessage blocks further
-                        actions until the QMessage is closed. If you don't
+        - do_not_block  bool: By default, a QMessageBox blocks further
+                        actions until the QMessageBox is closed. If you don't
                         want to block further actions, set this to True
 
         returns the function object corresponding to the clicked button.
@@ -164,8 +165,8 @@ class MessageBox(QMessageBox):
                             MessageBox.Yes, MessageBox.No, MessageBox.Abort,
                             MessageBox.Retry, and MessageBox.Ignore
                         value is a user-defined function object
-        - do_not_block  bool: By default, a QMessage blocks further
-                        actions until the QMessage is closed. If you don't
+        - do_not_block  bool: By default, a QMessageBox blocks further
+                        actions until the QMessageBox is closed. If you don't
                         want to block further actions, set this to True
 
         returns the function object corresponding to the clicked button.

--- a/gui/monitor/monitor.py
+++ b/gui/monitor/monitor.py
@@ -94,7 +94,7 @@ class Monitor(QtWidgets.QWidget):
             palette.setColor(role, QtGui.QColor(self.alarmcolor))
             self.setPalette(palette)
             if self.alarm_h is not None:
-                self.alarm_h.raise_alarm(self.alarm_min_code is self.is_alarm_min() else self.alarm_max_code)
+                self.alarm_h.raise_alarm(self.alarm_min_code if self.is_alarm_min() else self.alarm_max_code)
 
     def clear_alarm(self, event):
         """

--- a/gui/mvm_gui.py
+++ b/gui/mvm_gui.py
@@ -16,6 +16,7 @@ from mainwindow import MainWindow
 from communication.esp32serial import ESP32Serial
 from communication.fake_esp32serial import FakeESP32Serial
 from messagebox import MessageBox
+from alarm_handler import AlarmHandler
 
 def connect_esp32(config):
     try:
@@ -39,6 +40,7 @@ def connect_esp32(config):
 
     return esp32
 
+
 if __name__ == "__main__":
     base_dir = os.path.dirname(__file__)
     settings_file = os.path.join(base_dir, 'default_settings.yaml')
@@ -57,6 +59,8 @@ if __name__ == "__main__":
     watchdog = QtCore.QTimer()
     watchdog.timeout.connect(esp32.set_watchdog)
     watchdog.start(config["wdinterval"] * 1000)
+
+    alarm_h = AlarmHandler(config, esp32)
 
     window = MainWindow(config, esp32)
     window.show()

--- a/gui/mvm_gui.py
+++ b/gui/mvm_gui.py
@@ -16,7 +16,6 @@ from mainwindow import MainWindow
 from communication.esp32serial import ESP32Serial
 from communication.fake_esp32serial import FakeESP32Serial
 from messagebox import MessageBox
-from alarm_handler import AlarmHandler
 
 def connect_esp32(config):
     try:
@@ -59,8 +58,6 @@ if __name__ == "__main__":
     watchdog = QtCore.QTimer()
     watchdog.timeout.connect(esp32.set_watchdog)
     watchdog.start(config["wdinterval"] * 1000)
-
-    alarm_h = AlarmHandler(config, esp32)
 
     window = MainWindow(config, esp32)
     window.show()

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -23,6 +23,8 @@ void setup()
 
   random_measures = { "pressure", "bpm", "flow", "o2", "tidal", "peep",
                       "temperature", "power_mode", "battery" };
+
+  parameters["alarm"] = String(0);
 }
 
 // this is tricky, didn't had the time to think a better algo

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -25,6 +25,7 @@ void setup()
                       "temperature", "power_mode", "battery" };
 
   parameters["alarm"] = String(0);
+  parameters["warning"] = String(0);
 }
 
 // this is tricky, didn't had the time to think a better algo


### PR DESCRIPTION
Fixes #100 

- New class ESP32Alarm (and warnings) to handle the alarm and warnings codes from the ESP
- new class alarm_handler, which starts a QTimer to check if there is an alarm sent from the ESP
- If there is such alarm, a QMessageBox pops up. The message in the box is updated if the alarm changes while the box is on, or if more alarms come out.
- An alarm (`set alarm 1` for now) is also set to the ESP when one of the GUI monitors goes in alarm state.
- In the fakeEPS32serial class I added an alarm/warning simulator, which triggers and alarm or warning from time to time. This should be commented out because can get very annoying, but for now I am keeping it there so we can test the alarms. Please fell free to disable it.
- I updated mock.ino so it saves alarm and warning as 0 (there is no simulation here)