### PR TITLE
Issue 102

### DIFF
--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -1,5 +1,6 @@
 # The serial port to use:
 port: '/dev/cu.usbmodem143301'
+settings_file_path: '/dev/shm/settings.txt'
 
 # watchdog reset interval time in seconds
 wdinterval: 1

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -5,6 +5,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 
 from maindisplay.maindisplay import MainDisplay
 from settings.settings import Settings
+from settings.settingsfile import SettingsFile
 
 from toolbar.toolbar import Toolbar
 from menu.menu import Menu
@@ -287,7 +288,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.show_startup()
 
     def goto_resume_patient(self):
-        # TODO : implement start from current_settings.json
+        settings_file = SettingsFile(self.config["settings_file_path"])
+        settings = settings_file.load()
+        self.settings.update_config(settings)
+
         self.show_startup()
 
     def goto_settings(self):

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -22,7 +22,6 @@ from alarm_handler import AlarmHandler
 import pyqtgraph as pg
 import sys
 import time
-from pip._internal import self_outdated_check
 
 class MainWindow(QtWidgets.QMainWindow):
     def __init__(self, config, esp32, *args, **kwargs):

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -211,7 +211,10 @@ class Settings(QtWidgets.QMainWindow):
         '''
 
         for param, btn in self._all_spinboxes.items():
-            value = external_config[param]
+            if param in external_config:
+                value = external_config[param]
+            else:
+                value = self.config[param]["default"]
 
             if param == 'enable_backup':
                 btn.setChecked(value)

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -4,6 +4,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 import os
 import yaml
 import copy
+from .settingsfile import SettingsFile
 
 from presets.presets import Presets
 
@@ -218,7 +219,11 @@ class Settings(QtWidgets.QMainWindow):
         '''
         Sends the currently set values to the ESP
         '''
+
+        settings_to_file = {}
         for param, btn in self._all_spinboxes.items():
+            settings_to_file[param] = self._current_values[param]
+
             # value is the variable to be sent to the hardware,
             # so possibly converted from the settings
             if param == 'enable_backup':
@@ -248,6 +253,8 @@ class Settings(QtWidgets.QMainWindow):
                 self.toolsettings_lookup["respiratory_rate"].update(value)
             elif param == 'insp_expir_ratio':
                 self.toolsettings_lookup["insp_expir_ratio"].update(self._current_values[param])
+        settings_file = SettingsFile(self._config["settings_file_path"])
+        settings_file.store(settings_to_file)
 
 
 

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -205,6 +205,32 @@ class Settings(QtWidgets.QMainWindow):
         self.repaint()
         self.mainparent.exit_settings()
 
+    def update_config(self, external_config):
+        '''
+        Loads the presets from the config file
+        '''
+
+        for param, btn in self._all_spinboxes.items():
+            value = external_config[param]
+
+            if param == 'enable_backup':
+                btn.setChecked(value)
+                self._current_values[param] = value
+            else:
+                btn.setValue(value)
+                self._current_values[param] = value
+
+        # assign an easy lookup for toolsettings
+        self.toolsettings_lookup = {}
+        self.toolsettings_lookup["respiratory_rate"] = self._toolsettings["toolsettings_1"]
+        self.toolsettings_lookup["insp_expir_ratio"] = self._toolsettings["toolsettings_2"]
+
+        # setup the toolsettings with preset values
+        self.toolsettings_lookup["respiratory_rate"].update(external_config["respiratory_rate"])
+        self.toolsettings_lookup["insp_expir_ratio"].update(external_config["insp_expir_ratio"])
+
+        self.send_values_to_hardware()
+
 
     def apply_worker(self):
         '''

--- a/gui/settings/settingsfile.py
+++ b/gui/settings/settingsfile.py
@@ -68,11 +68,17 @@ class SettingsFile:
 
         arguments:
         - data          a JSON-convertible object to store
+
+        returns: True if the store succeeded, False otherwise
         """
 
-        with open(self.path, "w") as configfile:
-            json.dump(data, configfile)
-        self._write_md5()
+        try:
+            with open(self.path, "w") as configfile:
+                json.dump(data, configfile)
+            self._write_md5()
+            return True
+        except:
+            return False
 
     def load(self):
         """

--- a/gui/settings/settingsfile.py
+++ b/gui/settings/settingsfile.py
@@ -1,0 +1,91 @@
+import json
+from hashlib import md5
+from os import path as os_path
+
+
+__all__=('SettingsFile',)
+
+
+def _check_file(filename):
+    """
+    Checks whether the file exist on disk and has some content
+
+    arguments:
+    - filename:   the name of the file to be checked.
+    """
+
+    return os_path.exists(filename) and os_path.getsize(filename) > 0
+
+
+class SettingsFile:
+    """
+    A class to handle writing to and reading from a JSON settings file.
+    """
+
+    def __init__(self, path):
+        """
+        Constructor
+
+        arguments:
+        - path    the path of the configuration file
+        """
+
+        self.path = path
+
+    def _write_md5(self):
+        """
+        Store the md5 of the configuration file to a .md5 file
+        """
+
+        with open(self.path, "rb") as configfile:
+            value = md5(configfile.read()).hexdigest()
+        with open(self.path + ".md5", "w") as hashfile:
+            hashfile.write(value + "\n")
+
+    def _check_md5(self):
+        """
+        Check for config file validity
+
+        returns: True if the md5 of the config file matches with the md5
+                 file content, False otherwise.
+        """
+
+        md5_path = self.path + ".md5"
+
+        if _check_file(self.path) and _check_file(md5_path):
+            with open(md5_path, "r") as f:
+                challenge = f.read().rstrip()
+            with open(self.path, "rb") as configfile:
+                value = md5(configfile.read()).hexdigest()
+            return value == challenge
+        return False
+
+
+    def store(self, data):
+        """
+        Save the current configuration and update the md5 file.
+        The file will contain only the provided data.
+
+        arguments:
+        - data          a JSON-convertible object to store
+        """
+
+        with open(self.path, "w") as configfile:
+            json.dump(data, configfile)
+        self._write_md5()
+
+    def load(self):
+        """
+        Load the object contained in the config file if the md5 test
+        succeeded.
+
+        returns:        the deserialized content of the configuration file
+                        if the md5 test succeeded, an empty dictionary if
+                        failed.
+        """
+
+        if not self._check_md5():
+            return {}
+        else:
+            with open(self.path) as configfile:
+                return json.load(configfile)


### PR DESCRIPTION
implements the resume ventilation feature - solves issue #102 
- new library to store and load a settings file, with `md5` verification
- new config parameter `settings_file_path` defines the path of the settings file
- if Resume ventilation is chosen at program start, the settings file is loaded and parameters are sent to the hardware
- when the settings are updated via the gui, the settings file is updated accordingly