### PR TITLE
Issue 117

### DIFF
--- a/gui/alarms/alarms.py
+++ b/gui/alarms/alarms.py
@@ -163,34 +163,33 @@ class Alarms(QtWidgets.QWidget):
         self.show_settings(self.selected)
 
     def display_selected(self, slotname):
-        print(self.selected + " to " + slotname)
 
         # Assign selected to new spot and remove from old spot
         monitor = self.monitors[self.selected]
         plot = self.plots[self.selected]
-        print(self.monitor_slots)
-        print(self.plot_slots)
-        print(monitor.location)
         if monitor.location == slotname:
             # Plot/monitor is already where it should be on main display
+            print(self.selected + " already at " + slotname)
             return
         elif monitor.location != "None" and monitor.location is not None:
             # Plot/monitor is on main display, but somewhere else
             self.monitor_slots[monitor.location].removeWidget(monitor)
             self.plot_slots[monitor.location].removeWidget(plot)
+            print(self.selected + " from " + monitor.location + " to " + slotname)
         else:
             # Plot/monitor is not on main display
             self.layout.removeWidget(monitor)
             self.plot_hidden_slots.removeWidget(plot)
+            print(self.selected + " from cached to " + slotname)
 
-        # Set the new monitor location
-        monitor.location = slotname
-
+        # Set the new monitor location and swap with old location
         for (active_monitor, active_plot) in zip(self.active_monitors, self.active_plots):
             if active_monitor.location == slotname:
                 self.monitor_slots[slotname].removeWidget(active_monitor)
                 self.plot_slots[slotname].removeWidget(active_plot)
-                active_monitor.location = None
+                active_monitor.location = monitor.location
+                break
+        monitor.location = slotname
 
         self.populate_monitors_and_plots()
 

--- a/gui/alarms/alarms.py
+++ b/gui/alarms/alarms.py
@@ -183,7 +183,9 @@ class Alarms(QtWidgets.QWidget):
             print(self.selected + " from cached to " + slotname)
 
         # Set the new monitor location and swap with old location
-        for (active_monitor, active_plot) in zip(self.active_monitors, self.active_plots):
+        for (mon_name, plot_name) in zip(self.active_monitors, self.active_plots):
+            active_monitor = self.active_monitors[mon_name]
+            active_plot = self.active_plots[plot_name]
             if active_monitor.location == slotname:
                 self.monitor_slots[slotname].removeWidget(active_monitor)
                 self.plot_slots[slotname].removeWidget(active_plot)
@@ -199,8 +201,8 @@ class Alarms(QtWidgets.QWidget):
         If the monitor/plot pair is not displayed, it is shown in the alarms page.
         """
         # Get all active plots and monitors and put the remaining monitors on the alarms page
-        self.active_plots = []
-        self.active_monitors = []
+        self.active_plots = {}
+        self.active_monitors = {}
         for (i, name) in enumerate(self.monitors):
             monitor = self.monitors[name]
             plot = self.plots[name]
@@ -210,11 +212,22 @@ class Alarms(QtWidgets.QWidget):
                 if monitor.location == slotname:
                     self.monitor_slots[slotname].addWidget(monitor, 0, 0)
                     self.plot_slots[slotname].addWidget(plot, 0, 0)
-                    self.active_monitors.append(monitor)
-                    self.active_plots.append(plot)
+                    self.active_monitors[slotname] = monitor
+                    self.active_plots[slotname] = plot
                     break
 
-        return (self.active_monitors, self.active_plots)
+
+        # Disconnect old connections
+        self.mainparent.frozen_bot.disconnect_workers()
+        self.mainparent.frozen_right.disconnect_workers()
+
+        # Connect the frozen plots
+        # Requires building of an ordered array to associate the correct controls with the plot.
+        active_plots = []
+        for slotname in self.plot_slots:
+            active_plots.append(self.active_plots[slotname])
+        self.mainparent.frozen_bot.connect_workers(self.mainparent.data_filler, active_plots)
+        self.mainparent.frozen_right.connect_workers(active_plots)
 
     def config_monitors(self):
         """

--- a/gui/alarms/alarms.py
+++ b/gui/alarms/alarms.py
@@ -214,7 +214,6 @@ class Alarms(QtWidgets.QWidget):
                     self.active_plots.append(plot)
                     break
 
-        print(self.active_monitors)
         return (self.active_monitors, self.active_plots)
 
     def config_monitors(self):

--- a/gui/alarms/alarms.py
+++ b/gui/alarms/alarms.py
@@ -164,6 +164,34 @@ class Alarms(QtWidgets.QWidget):
 
     def display_selected(self, slotname):
         print(self.selected + " to " + slotname)
+
+        # Assign selected to new spot and remove from old spot
+        monitor = self.monitors[self.selected]
+        plot = self.plots[self.selected]
+        print(self.monitor_slots)
+        print(self.plot_slots)
+        print(monitor.location)
+        if monitor.location == slotname:
+            # Plot/monitor is already where it should be on main display
+            return
+        elif monitor.location != "None" and monitor.location is not None:
+            # Plot/monitor is on main display, but somewhere else
+            self.monitor_slots[monitor.location].removeWidget(monitor)
+            self.plot_slots[monitor.location].removeWidget(plot)
+        else:
+            # Plot/monitor is not on main display
+            self.layout.removeWidget(monitor)
+            self.plot_hidden_slots.removeWidget(plot)
+
+        # Set the new monitor location
+        monitor.location = slotname
+
+        for (active_monitor, active_plot) in zip(self.active_monitors, self.active_plots):
+            if active_monitor.location == slotname:
+                self.monitor_slots[slotname].removeWidget(active_monitor)
+                self.plot_slots[slotname].removeWidget(active_plot)
+                active_monitor.location = None
+
         self.populate_monitors_and_plots()
 
     def populate_monitors_and_plots(self):
@@ -179,15 +207,15 @@ class Alarms(QtWidgets.QWidget):
             plot = self.plots[name]
             self.layout.addWidget(monitor, int(i % 3), 10-int(i / 3)) 
             self.plot_hidden_slots.addWidget(plot, i)
-            for (mon_slotname, plot_slotname) in zip(self.monitor_slots, self.plot_slots):
-                monitor_slot = self.monitor_slots[mon_slotname]
-                if monitor.location == mon_slotname:
-                    self.monitor_slots[mon_slotname].addWidget(monitor, 0, 0)
-                    self.plot_slots[plot_slotname].addWidget(plot, 0, 0)
+            for slotname in self.plot_slots:
+                if monitor.location == slotname:
+                    self.monitor_slots[slotname].addWidget(monitor, 0, 0)
+                    self.plot_slots[slotname].addWidget(plot, 0, 0)
                     self.active_monitors.append(monitor)
                     self.active_plots.append(plot)
                     break
 
+        print(self.active_monitors)
         return (self.active_monitors, self.active_plots)
 
     def config_monitors(self):

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -13,12 +13,13 @@ from . import ESP32Alarm, ESP32Warning
 
 class FakeESP32Serial:
     peep = peep()
-    def __init__(self):
+    def __init__(self, alarm_rate=0.1):
         self.lock = Lock()
         self.set_params = {"alarm": 0, "warning": 0}
         self.random_params = ["pressure", "flow", "o2", "bpm", "tidal",
                               "peep", "temperature", "power_mode",
                               "battery" ]
+        self.alarm_rate = alarm_rate
 
     def set(self, name, value):
         """
@@ -63,7 +64,7 @@ class FakeESP32Serial:
             retval = 0
 
             if name == 'alarm' or name == 'warning':
-                if random.uniform(0, 1) < 0.1:
+                if random.uniform(0, 1) < self.alarm_rate:
                     retval = int(random.uniform(0, 2147483647))
                     print('**************************************************** ALARM/WARINING SIMULATION, retval', retval)
                 else:

--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -226,11 +226,11 @@ class DataFiller():
                                       self._data[name],
                                       pen=pg.mkPen(color, width=self._config['line_width']))
 
-            self.update_monitor(name)
-
             if self._looping:
                 x_val = self._xdata[self._looping_data_idx[name]] - self._sampling * 0.1
                 self._looping_lines[name].setValue(x_val)
+
+        self.update_monitor(name)
 
         return True
 

--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -79,7 +79,7 @@ mon_inspiratory_pressure:
     plot_var: pressure
     alarm_min_code: 8
     alarm_max_code: 9
-    location: "monitor_top_slot"
+    location: "top_slot"
 
 mon_tidal_volume: 
     name: "V<sub>tidal</sub>"
@@ -94,7 +94,7 @@ mon_tidal_volume:
     plot_var: tidal
     alarm_min_code: 14
     alarm_max_code: 15
-    location: "monitor_mid_slot"
+    location: "mid_slot"
 
 mon_flow: 
     name: "MVe"
@@ -109,7 +109,7 @@ mon_flow:
     plot_var: flow
     alarm_min_code: 11
     alarm_max_code: 12
-    location: "monitor_bot_slot"
+    location: "bot_slot"
 
 mon_oxygen_concentration: 
     name: "O<sub>2</sub> Conc." 

--- a/gui/frozenplots/frozenplots.py
+++ b/gui/frozenplots/frozenplots.py
@@ -25,6 +25,11 @@ class FrozenPlotsBottomMenu(QtWidgets.QWidget):
         # X axes are linked, so only need to manipulate 1 plot
         self.xzoom.connect_workers(plots[0].getPlotItem())
 
+    def disconnect_workers(self):
+        try: self.button_reset_zoom.pressed.disconnect() 
+        except Exception: pass
+        self.xzoom.disconnect_workers()
+
 class FrozenPlotsRightMenu(QtWidgets.QWidget):
     def __init__(self, *args):
         """
@@ -47,6 +52,11 @@ class FrozenPlotsRightMenu(QtWidgets.QWidget):
         self.yzoom_top.connect_workers(plots[0].getPlotItem())
         self.yzoom_mid.connect_workers(plots[1].getPlotItem())
         self.yzoom_bot.connect_workers(plots[2].getPlotItem())
+
+    def disconnect_workers(self):
+        self.yzoom_top.disconnect_workers()
+        self.yzoom_mid.disconnect_workers()
+        self.yzoom_bot.disconnect_workers()
     
 class YZoom(QtWidgets.QWidget):
     def __init__(self, *args):
@@ -66,6 +76,16 @@ class YZoom(QtWidgets.QWidget):
         self.zoom_factor = 1.25
         self.translate_factor = 0.1
         
+    def disconnect_workers(self):
+        try: self.button_plus.pressed.disconnect() 
+        except Exception: pass
+        try: self.button_minus.pressed.disconnect() 
+        except Exception: pass
+        try: self.button_up.pressed.disconnect() 
+        except Exception: pass
+        try: self.button_down.pressed.disconnect() 
+        except Exception: pass
+
     def connect_workers(self, plot):
         self.button_plus.pressed.connect(lambda: self.zoom_in(plot))
         self.button_minus.pressed.connect(lambda: self.zoom_out(plot))
@@ -111,6 +131,16 @@ class XZoom(QtWidgets.QWidget):
         self.button_minus.pressed.connect(lambda: self.zoom_out(plot))
         self.button_left.pressed.connect(lambda: self.shift_left(plot))
         self.button_right.pressed.connect(lambda: self.shift_right(plot))
+
+    def disconnect_workers(self):
+        try: self.button_plus.pressed.disconnect() 
+        except Exception: pass
+        try: self.button_minus.pressed.disconnect() 
+        except Exception: pass
+        try: self.button_left.pressed.disconnect() 
+        except Exception: pass
+        try: self.button_right.pressed.disconnect() 
+        except Exception: pass
         
     def zoom_in(self, plot):
         plot.getViewBox().scaleBy(x=1/self.zoom_factor)

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -243,6 +243,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.config[name]["alarm_max_code"])
             self.monitors[name] = monitor
             plot = pg.PlotWidget()
+            plot.setFixedHeight(130)
             self.plots[name] = plot
 
             # Make connections to data filler

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -251,7 +251,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.data_filler.connect_plot(name, plot)
 
         self.plots_settings.connect_monitors_and_plots(self)
-        self.update_monitors_and_plots()
+        self.plots_settings.populate_monitors_and_plots()
         self.button_applyalarm.pressed.connect(self.plots_settings.apply_selected)
         self.button_resetalarm.pressed.connect(self.plots_settings.reset_selected)
         self.button_topalarm.pressed.connect(lambda slotname=slot_names[0]:
@@ -284,14 +284,6 @@ class MainWindow(QtWidgets.QMainWindow):
         '''
         self.settings = Settings(self)
         self.toppane.insertWidget(self.toppane.count(), self.settings)
-
-
-    def update_monitors_and_plots(self):
-        (self.active_monitors, self.active_plots) = self.plots_settings.populate_monitors_and_plots()
-        # Connect buttons on freeze menus
-        self.frozen_bot.connect_workers(self.data_filler, self.active_plots)
-        self.frozen_right.connect_workers(self.active_plots)
-
 
     def goto_new_patient(self):
         # TODO : implement start from default_settings

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -198,21 +198,30 @@ class MainWindow(QtWidgets.QMainWindow):
         and max. The current value and optional stats for the monitored value (mean, max) are set
         here.
         '''
+        # Monitor slot widget names
         monitor_slot_names = [
                 "monitor_top_slot",
                 "monitor_mid_slot",
                 "monitor_bot_slot"]
 
+        # plot slot widget names
+        plot_slot_names = [
+                "plot_top_slot",
+                "plot_mid_slot",
+                "plot_bot_slot"]
+        
+        # Reference names that link plot and monitor slots
+        slot_names = [
+                "top_slot",
+                "mid_slot",
+                "bot_slot"]
+
+        # The name of the monitored field in the default_settings.yaml config file
         monitor_names = [
                 "mon_inspiratory_pressure",
                 "mon_tidal_volume",
                 "mon_flow",
                 "mon_oxygen_concentration"]
-
-        plot_slot_names = [
-                "plot_top_slot",
-                "plot_mid_slot",
-                "plot_bot_slot"]
 
         self.monitors = {}
         self.monitor_slots = {}
@@ -220,12 +229,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.plot_slots = {}
 
         # Get displayed monitor slots
-        for barname in monitor_slot_names:
-            self.monitor_slots[barname] = self.rightbar.findChild(QtWidgets.QGridLayout, barname)
+        for (slotname, barname) in zip(slot_names, monitor_slot_names):
+            self.monitor_slots[slotname] = self.rightbar.findChild(QtWidgets.QGridLayout, barname)
 
         # Get displayed plot slots
-        for barname in plot_slot_names:
-            self.plot_slots[barname] = self.main.findChild(QtWidgets.QGridLayout, barname)
+        for (slotname, barname) in zip(slot_names, plot_slot_names):
+            self.plot_slots[slotname] = self.main.findChild(QtWidgets.QGridLayout, barname)
 
         # Generate monitors and plots
         for name in monitor_names:
@@ -244,11 +253,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.update_monitors_and_plots()
         self.button_applyalarm.pressed.connect(self.plots_settings.apply_selected)
         self.button_resetalarm.pressed.connect(self.plots_settings.reset_selected)
-        self.button_topalarm.pressed.connect(lambda slotname=plot_slot_names[0]:
+        self.button_topalarm.pressed.connect(lambda slotname=slot_names[0]:
                 self.plots_settings.display_selected(slotname))
-        self.button_midalarm.pressed.connect(lambda slotname=plot_slot_names[1]:
+        self.button_midalarm.pressed.connect(lambda slotname=slot_names[1]:
                 self.plots_settings.display_selected(slotname))
-        self.button_botalarm.pressed.connect(lambda slotname=plot_slot_names[2]:
+        self.button_botalarm.pressed.connect(lambda slotname=slot_names[2]:
                 self.plots_settings.display_selected(slotname))
 
         '''

--- a/gui/mvm_gui.py
+++ b/gui/mvm_gui.py
@@ -20,9 +20,13 @@ from messagebox import MessageBox
 def connect_esp32(config):
     try:
         if 'fakeESP32' in sys.argv:
+            if 'disableSimAlarms' in sys.argv:
+                alarm_rate = 0
+            else:
+                alarm_rate = 0.1
             print('******* Simulating communication with ESP32')
             err_msg = "Cannot setup FakeESP32Serial"
-            esp32 = FakeESP32Serial()
+            esp32 = FakeESP32Serial(alarm_rate=alarm_rate)
             esp32.set("wdenable", 1)
         else:
             err_msg = "Cannot communicate with port %s" % config['port']


### PR DESCRIPTION
Fixed #117 

- Can now swap monitors and plots from alarms page
- Frozen plots maintain association with the currently active plots
![image](https://user-images.githubusercontent.com/35709681/78947029-4c2c3180-7a92-11ea-8067-d9ff4e5a439b.png)
![image](https://user-images.githubusercontent.com/35709681/78947039-53ebd600-7a92-11ea-8006-9c8acdcedc15.png)
