### PR TITLE
Issue 85

### DIFF
--- a/gui/settings/settings.ui
+++ b/gui/settings/settings.ui
@@ -81,6 +81,22 @@ QDoubleSpinBox::down-button  {
       <property name="focusPolicy">
        <enum>Qt::StrongFocus</enum>
       </property>
+      <property name="styleSheet">
+       <string notr="true">QTabBar::tab {
+    /* make the tab large enough to show the full text */
+    width: 270px;
+}
+
+QTabBar::tab:selected {
+    /* make selected tabs text bold and with white background*/
+    background: #FFFFFF;
+    font: bold;
+}
+
+QTabBar::tab:!selected {
+    margin-top: 2px; /* make non-selected tabs look smaller */
+}</string>
+      </property>
       <property name="tabPosition">
        <enum>QTabWidget::North</enum>
       </property>
@@ -88,7 +104,7 @@ QDoubleSpinBox::down-button  {
        <enum>QTabWidget::Triangular</enum>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="iconSize">
        <size>
@@ -97,7 +113,7 @@ QDoubleSpinBox::down-button  {
        </size>
       </property>
       <property name="elideMode">
-       <enum>Qt::ElideRight</enum>
+       <enum>Qt::ElideNone</enum>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">

--- a/gui/settings/settings.ui
+++ b/gui/settings/settings.ui
@@ -88,7 +88,7 @@ QDoubleSpinBox::down-button  {
        <enum>QTabWidget::Triangular</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="iconSize">
        <size>
@@ -638,7 +638,7 @@ QDoubleSpinBox::down-button  {
         <property name="geometry">
          <rect>
           <x>214</x>
-          <y>301</y>
+          <y>251</y>
           <width>231</width>
           <height>40</height>
          </rect>
@@ -694,7 +694,7 @@ QDoubleSpinBox::down-button  {
         <property name="geometry">
          <rect>
           <x>460</x>
-          <y>290</y>
+          <y>240</y>
           <width>321</width>
           <height>60</height>
          </rect>
@@ -721,7 +721,7 @@ QDoubleSpinBox::down-button  {
         <property name="geometry">
          <rect>
           <x>180</x>
-          <y>290</y>
+          <y>240</y>
           <width>20</width>
           <height>71</height>
          </rect>
@@ -964,7 +964,7 @@ QDoubleSpinBox::down-button  {
         <property name="geometry">
          <rect>
           <x>540</x>
-          <y>290</y>
+          <y>240</y>
           <width>161</width>
           <height>60</height>
          </rect>
@@ -1232,7 +1232,7 @@ QDoubleSpinBox::down-button  {
         <property name="geometry">
          <rect>
           <x>30</x>
-          <y>310</y>
+          <y>260</y>
           <width>131</width>
           <height>41</height>
          </rect>
@@ -1242,7 +1242,7 @@ QDoubleSpinBox::down-button  {
         <property name="geometry">
          <rect>
           <x>0</x>
-          <y>270</y>
+          <y>220</y>
           <width>191</width>
           <height>40</height>
          </rect>
@@ -1259,6 +1259,29 @@ QDoubleSpinBox::down-button  {
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+       <widget class="QLabel" name="label_4">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>315</y>
+          <width>781</width>
+          <height>31</height>
+         </rect>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>15</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: red;</string>
+        </property>
+        <property name="text">
+         <string>NOTE: refer to the &quot;Automatic Mode Settings&quot; tab for settings used in backup state.</string>
         </property>
        </widget>
       </widget>


### PR DESCRIPTION
- make the tab large enough to show the full label
- make selected tabs text bold and with white background
- make non-selected tabs look smaller
- move the "backup"-related widgets 50px above, add red label
