### PR TITLE
Issue 129 et al

### DIFF
--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -52,8 +52,16 @@ class FakeESP32Serial(QtWidgets.QMainWindow):
         self.alarms_checkboxes = {}
         self.warning_checkboxes = {}
         self._connect_alarm_and_warning_widgets()
+        self._connect_status_widgets()
 
-        self.set_params = {"alarm": 0, "warning": 0, "temperature": 40}
+
+        self.set_params = {
+            "run": 0,
+            "mode": 0,
+            "backup": 0,
+            "alarm": 0, 
+            "warning": 0, 
+            "temperature": 40}
         self.alarm_rate = alarm_rate
 
         self.event_log = self.findChild(QtWidgets.QPlainTextEdit, "event_log")
@@ -165,6 +173,15 @@ class FakeESP32Serial(QtWidgets.QMainWindow):
                 "raise_warning_btn")
 
         self.raise_warnings_button.pressed.connect(self._compute_and_raise_warnings)
+
+    def _connect_status_widgets(self):
+
+        self.btn_change_status.clicked.connect(self._update_status)
+
+    def _update_status(self):
+        self.set('run',    int(self.status_run.isChecked()))
+        self.set('mode',   int(self.status_mode.isChecked()))
+        self.set('backup', int(self.status_backup.isChecked()))
 
     def log(self, message):
         self.event_log.appendPlainText(message)

--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -175,10 +175,16 @@ class FakeESP32Serial(QtWidgets.QMainWindow):
         self.raise_warnings_button.pressed.connect(self._compute_and_raise_warnings)
 
     def _connect_status_widgets(self):
-
+        '''
+        Connects the Change Status button to the
+        appropriate callback
+        '''
         self.btn_change_status.clicked.connect(self._update_status)
 
     def _update_status(self):
+        '''
+        Changes the run,mode,backup variables in the ESP
+        '''
         self.set('run',    int(self.status_run.isChecked()))
         self.set('mode',   int(self.status_mode.isChecked()))
         self.set('backup', int(self.status_backup.isChecked()))

--- a/gui/communication/fakeesp32.ui
+++ b/gui/communication/fakeesp32.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>600</height>
+    <height>635</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,7 +47,7 @@
       <rect>
        <x>0</x>
        <y>10</y>
-       <width>425</width>
+       <width>461</width>
        <height>104</height>
       </rect>
      </property>
@@ -174,7 +174,7 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>350</y>
+      <y>410</y>
       <width>131</width>
       <height>16</height>
      </rect>
@@ -240,13 +240,94 @@
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>370</y>
+      <y>440</y>
       <width>781</width>
-      <height>221</height>
+      <height>181</height>
      </rect>
     </property>
     <property name="plainText">
      <string/>
+    </property>
+   </widget>
+   <widget class="QFrame" name="status_frame">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>370</y>
+      <width>781</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::StyledPanel</enum>
+    </property>
+    <property name="frameShadow">
+     <enum>QFrame::Raised</enum>
+    </property>
+    <widget class="QPushButton" name="btn_change_status">
+     <property name="geometry">
+      <rect>
+       <x>640</x>
+       <y>0</y>
+       <width>131</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Change Status</string>
+     </property>
+    </widget>
+    <widget class="QCheckBox" name="status_run">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>10</y>
+       <width>124</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Run</string>
+     </property>
+    </widget>
+    <widget class="QCheckBox" name="status_mode">
+     <property name="geometry">
+      <rect>
+       <x>130</x>
+       <y>10</y>
+       <width>124</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Mode</string>
+     </property>
+    </widget>
+    <widget class="QCheckBox" name="status_backup">
+     <property name="geometry">
+      <rect>
+       <x>260</x>
+       <y>10</y>
+       <width>124</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Backup</string>
+     </property>
+    </widget>
+   </widget>
+   <widget class="QLabel" name="label_5">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>350</y>
+      <width>111</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Status</string>
     </property>
    </widget>
   </widget>

--- a/gui/controller_status.py
+++ b/gui/controller_status.py
@@ -1,0 +1,46 @@
+'''
+Constanty checks the status of the ESP controller.
+'''
+
+# from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5.QtCore import QTimer
+
+from messagebox import MessageBox
+
+
+class ControllerStatus:
+    '''
+    This class constanty checks 
+    the status of the ESP controller.
+    Is it running? In which mode?
+    Has it entered backup mode?
+    '''
+
+    def __init__(self, config, esp32):
+        '''
+        Constructor
+
+        arguments:
+        - config: the dictionary storing the configuration
+        - esp32: the esp32serial object
+        '''
+
+        self._config = config
+        self._esp32 = esp32
+
+        self._init_settings_panel()
+
+        self._timer = QTimer()
+        self._timer.timeout.connect(self._esp32_io)
+        self._start_timer()
+
+    def _init_settings_panel(self):
+        return
+
+    def _esp32_io(self):
+        return
+
+
+
+
+ 

--- a/gui/controller_status.py
+++ b/gui/controller_status.py
@@ -40,6 +40,9 @@ class ControllerStatus:
     def _esp32_io(self):
         return
 
+    def _start_timer(self):
+        self._timer.start()
+
 
 
 

--- a/gui/controller_status.py
+++ b/gui/controller_status.py
@@ -16,17 +16,19 @@ class ControllerStatus:
     Has it entered backup mode?
     '''
 
-    def __init__(self, config, esp32):
+    def __init__(self, config, esp32, settings):
         '''
         Constructor
 
         arguments:
         - config: the dictionary storing the configuration
         - esp32: the esp32serial object
+        - settings: the Settings panel
         '''
 
         self._config = config
         self._esp32 = esp32
+        self._settings = settings
 
         self._init_settings_panel()
 
@@ -34,8 +36,23 @@ class ControllerStatus:
         self._timer.timeout.connect(self._esp32_io)
         self._start_timer()
 
+
     def _init_settings_panel(self):
-        return
+        '''
+        Initializes the settings values.
+        If the ESP if running, read the current parameters
+        and set them in the Setting panel. 
+        If the ESP is not running, don't do anything here,
+        and leave the default behaviour.
+        '''
+        
+        if not self._esp32.get('run'):
+            return
+
+        for param, esp_name in self._config['esp_settable_param'].items():
+            print('Reading Settings parameters from ESP:', param, self._esp32.get(esp_name))
+            self._settings.update_spinbox_value(param, self._esp32.get(esp_name))
+
 
     def _esp32_io(self):
         return

--- a/gui/controller_status.py
+++ b/gui/controller_status.py
@@ -59,6 +59,10 @@ class ControllerStatus:
 
 
     def _esp32_io(self):
+        '''
+        The callback function called every time the 
+        QTimer times out.
+        '''
 
         try:
             self._call_esp32()
@@ -67,6 +71,11 @@ class ControllerStatus:
 
 
     def _call_esp32(self):
+        '''
+        Gets the run, mode and backup vairables
+        from the ESP, and passes them to the 
+        StartStopWorker class.
+        '''
 
         self._start_stop_worker.set_run(int(self._esp32.get('run')))
         self._start_stop_worker.set_mode(int(self._esp32.get('mode')))
@@ -79,6 +88,10 @@ class ControllerStatus:
 
 
     def _open_backup_warning(self):
+        '''
+        Opens a warning message if the ventilator
+        changed from assisted to automatic ventilation.
+        '''
         msg = MessageBox()
 
         callbacks = {msg.Ok: self._acknowlege_backup}
@@ -110,10 +123,16 @@ class ControllerStatus:
 
 
     def _acknowlege_backup(self):
+        '''
+        Sets _backup_ackowledged to True
+        '''
         self._backup_ackowledged = True
 
 
     def _start_timer(self):
+        '''
+        Starts the QTimer.
+        '''
         self._timer.start(self._config["status_sampling_interval"] * 1000)
 
 

--- a/gui/controller_status.py
+++ b/gui/controller_status.py
@@ -46,12 +46,12 @@ class ControllerStatus:
         and leave the default behaviour.
         '''
         
-        if not self._esp32.get('run'):
+        if not int(self._esp32.get('run')):
             return
 
         for param, esp_name in self._config['esp_settable_param'].items():
             print('Reading Settings parameters from ESP:', param, self._esp32.get(esp_name))
-            self._settings.update_spinbox_value(param, self._esp32.get(esp_name))
+            self._settings.update_spinbox_value(param, int(self._esp32.get(esp_name)))
 
 
     def _esp32_io(self):

--- a/gui/controller_status.py
+++ b/gui/controller_status.py
@@ -16,7 +16,7 @@ class ControllerStatus:
     Has it entered backup mode?
     '''
 
-    def __init__(self, config, esp32, settings):
+    def __init__(self, config, esp32, settings, start_stop_worker):
         '''
         Constructor
 
@@ -24,11 +24,14 @@ class ControllerStatus:
         - config: the dictionary storing the configuration
         - esp32: the esp32serial object
         - settings: the Settings panel
+        - start_stop_worker: the StartStopWorker class 
+                             that takes care of start/stop operations
         '''
 
         self._config = config
         self._esp32 = esp32
         self._settings = settings
+        self._start_stop_worker = start_stop_worker
 
         self._init_settings_panel()
 
@@ -55,6 +58,13 @@ class ControllerStatus:
 
 
     def _esp32_io(self):
+
+        # run    = int(self._esp32.get('run'))
+        # mode   = int(self._esp32.get('mode'))
+        backup = int(self._esp32.get('backup'))
+
+        self._start_stop_worker.set_run(int(self._esp32.get('run')))
+        self._start_stop_worker.set_mode(int(self._esp32.get('mode')))
         return
 
     def _start_timer(self):

--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -55,13 +55,13 @@ class DataFiller():
         self._data[name] = np.linspace(0, 0, self._n_samples)
         self._historic_data[name] = np.linspace(0, 0, self._n_historic_samples)
         self._plots[name].setData(self._xdata, self._data[name])
-        self._colors[name] = plot_config['color'] 
+        self._colors[name] = plot_config['color']
         self._looping_data_idx[name] = 0
 
         # Set the Y axis
-        y_axis_label = plot_config['name'] 
+        y_axis_label = plot_config['name']
         y_axis_label += ' '
-        y_axis_label += plot_config['units'] 
+        y_axis_label += plot_config['units']
         plot.setLabel(axis='left', text=y_axis_label)
 
         # Set the X axis
@@ -175,11 +175,11 @@ class DataFiller():
         Connect a monitor to this class by
         storing it in a dictionary
         '''
-        name = monitor.observable 
+        name = monitor.observable
         self._monitors[name] = monitor
-        
+
         self._data[name] = np.linspace(0, 0, self._n_samples)
-        
+
         self._looping_data_idx[name] = 0
 
 

--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -25,7 +25,8 @@ class DataFiller():
         self._default_ranges = {}
         self._config = config
         self._n_samples = self._config['nsamples']
-        self._n_historic_samples = self._config['historic_nsamples']
+        self._n_historic_samples = self._config.get('historic_nsamples',
+                200)
         self._sampling = self._config['sampling_interval']
         self._time_window = self._n_samples * self._sampling # seconds
         self._xdata = np.linspace(-self._time_window, 0, self._n_samples)

--- a/gui/data_filler.py
+++ b/gui/data_filler.py
@@ -120,9 +120,10 @@ class DataFiller():
         # Calculate the max and min using the larger historical data sample
         ymax = np.max(self._historic_data[name])
         ymin = np.min(self._historic_data[name])
+        span = ymax - ymin
 
-        ymax += (ymax - ymin) * 0.1
-        ymin -= (ymax - ymin) * 0.1
+        ymax += span * 0.1
+        ymin -= span * 0.1
 
         self._qtgraphs[name].setYRange(ymin, ymax)
 

--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -36,6 +36,12 @@ nsamples: 100
 # time in seconds between two data retrieval
 sampling_interval: 0.1
 
+# time in seconds between two status checks
+status_sampling_interval: 0.5
+
+# number of samples used for the y-axes plot autoscale feature (default:
+# 200)
+historic_nsamples: 200
 # The parameters that can be set on the ESP
 # The values below must match those used in the ESP
 esp_settable_param:

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -20,6 +20,7 @@ from data_filler import DataFiller
 from data_handler import DataHandler
 from start_stop_worker import StartStopWorker
 from alarm_handler import AlarmHandler
+from controller_status import ContollerStatus
 
 import pyqtgraph as pg
 import sys
@@ -260,6 +261,12 @@ class MainWindow(QtWidgets.QMainWindow):
         '''
         self.settings = Settings(self)
         self.toppane.insertWidget(self.toppane.count(), self.settings)
+
+        '''
+        Instantiate ContollerStatus
+        '''
+        self._ctr_status = ContollerStatus(config, self.esp32)
+        
 
     def set_colors(self):
         # Monitors bar background

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -20,7 +20,7 @@ from data_filler import DataFiller
 from data_handler import DataHandler
 from start_stop_worker import StartStopWorker
 from alarm_handler import AlarmHandler
-from controller_status import ContollerStatus
+from controller_status import ControllerStatus
 
 import pyqtgraph as pg
 import sys
@@ -263,9 +263,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.toppane.insertWidget(self.toppane.count(), self.settings)
 
         '''
-        Instantiate ContollerStatus
+        Instantiate ControllerStatus
         '''
-        self._ctr_status = ContollerStatus(config, self.esp32)
+        self._ctr_status = ControllerStatus(config, self.esp32)
         
 
     def set_colors(self):

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -265,7 +265,7 @@ class MainWindow(QtWidgets.QMainWindow):
         '''
         Instantiate ControllerStatus
         '''
-        self._ctr_status = ControllerStatus(config, self.esp32, self.settings)
+        self._ctr_status = ControllerStatus(config, self.esp32, self.settings, self._start_stop_worker)
 
 
     def set_colors(self):

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -244,10 +244,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.settings = Settings(self)
         self.toppane.insertWidget(self.toppane.count(), self.settings)
 
-        '''
-        Instantiate ControllerStatus
-        '''
-        self._ctr_status = ControllerStatus(config, self.esp32, self.settings, self._start_stop_worker)
 
         '''
         Set up start/stop auto/min mode buttons.
@@ -267,6 +263,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.button_startstop.released.connect(self._start_stop_worker.toggle_start_stop)
         self.button_autoassist.released.connect(self._start_stop_worker.toggle_mode)
+
+        '''
+        Instantiate ControllerStatus
+        '''
+        self._ctr_status = ControllerStatus(config, self.esp32, self.settings, self._start_stop_worker)
+
 
 
     def set_colors(self):

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -265,8 +265,8 @@ class MainWindow(QtWidgets.QMainWindow):
         '''
         Instantiate ControllerStatus
         '''
-        self._ctr_status = ControllerStatus(config, self.esp32)
-        
+        self._ctr_status = ControllerStatus(config, self.esp32, self.settings)
+
 
     def set_colors(self):
         # Monitors bar background

--- a/gui/settings/mvmtoggle.py
+++ b/gui/settings/mvmtoggle.py
@@ -36,3 +36,15 @@ class MVMToggle(QtWidgets.QPushButton):
             sw_rect.moveLeft(-width)
         painter.drawRoundedRect(sw_rect, radius, radius)
         painter.drawText(sw_rect, Qt.AlignCenter, label)
+
+    def setValue(self, value):
+        '''
+        Just calls setChecked().
+        '''
+        return self.setChecked(value)
+
+    def value(self):
+        '''
+        Just calls isChecked().
+        '''
+        return int(self.isChecked())

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -166,14 +166,12 @@ class Settings(QtWidgets.QMainWindow):
         for param, btn in self._all_spinboxes.items():
             value_config = self._config[param]
 
-            if param == 'enable_backup':
-                btn.setChecked(value_config['default'])
-                self._current_values[param] = value_config['default']
-            else:
-                btn.setValue(value_config['default'])
+            btn.setValue(value_config['default'])
+            self._current_values[param] = value_config['default']
+
+            if param != 'enable_backup':
                 btn.setMinimum(value_config['min'])
                 btn.setMaximum(value_config['max'])
-                self._current_values[param] = value_config['default']
 
         # assign an easy lookup for toolsettings
         self.toolsettings_lookup = {}
@@ -198,11 +196,8 @@ class Settings(QtWidgets.QMainWindow):
 
         # Restore to previous values
         for param, btn in self._all_spinboxes.items():
-            if param == 'enable_backup':
-                btn.setChecked(self._current_values[param])
-            else:
-                print('resetting', param, 'to ', self._current_values[param])
-                btn.setValue(self._current_values[param])
+            print('Resetting', param, 'to ', self._current_values[param])
+            btn.setValue(self._current_values[param])
 
         self.repaint()
         self.mainparent.exit_settings()
@@ -235,12 +230,8 @@ class Settings(QtWidgets.QMainWindow):
             else:
                 value = self.config[param]["default"]
 
-            if param == 'enable_backup':
-                btn.setChecked(value)
-                self._current_values[param] = value
-            else:
-                btn.setValue(value)
-                self._current_values[param] = value
+            btn.setValue(value)
+            self._current_values[param] = value
 
         # assign an easy lookup for toolsettings
         self.toolsettings_lookup = {}
@@ -319,8 +310,5 @@ class Settings(QtWidgets.QMainWindow):
         '''
         for param, btn in self._all_spinboxes.items():
             if self.sender() == btn:
-                if param == 'enable_backup':
-                    self._current_values_temp[param] = int(btn.isChecked())
-                else:
-                    self._current_values_temp[param] = btn.value()
+                self._current_values_temp[param] = btn.value()
 

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -54,6 +54,8 @@ class Settings(QtWidgets.QMainWindow):
             'minimal_resp_rate': self.fake_btn_min_resp_rate,
         }
 
+        self.toolsettings_lookup = None
+
         # Connect all widgets
         self.connect_workers()
 
@@ -204,6 +206,23 @@ class Settings(QtWidgets.QMainWindow):
 
         self.repaint()
         self.mainparent.exit_settings()
+
+    def update_spinbox_value(self, param, value):
+        '''
+        '''
+        if param in self._all_spinboxes:
+            self._all_spinboxes[param].setValue(value)
+            self._current_values[param] = value
+        else:
+            raise Exception('Cannot set value to SpinBox with name', param)
+
+        if self.toolsettings_lookup is None:
+            raise Exception('Trying to update SpinBox values but toolsettings_lookup was not set!')
+
+        if param in self.toolsettings_lookup:
+            self.toolsettings_lookup[param].update(value)
+
+
 
     def update_config(self, external_config):
         '''

--- a/gui/settings/settings.ui
+++ b/gui/settings/settings.ui
@@ -84,7 +84,7 @@ QDoubleSpinBox::down-button  {
       <property name="styleSheet">
        <string notr="true">QTabBar::tab {
     /* make the tab large enough to show the full text */
-    width: 270px;
+    width: 260px;
 }
 
 QTabBar::tab:selected {
@@ -1303,13 +1303,13 @@ QTabBar::tab:!selected {
       </widget>
       <widget class="QWidget" name="tab_special_ops">
        <attribute name="title">
-        <string>Special Operations</string>
+        <string>Maintenance</string>
        </attribute>
        <widget class="QWidget" name="horizontalLayoutWidget">
         <property name="geometry">
          <rect>
           <x>20</x>
-          <y>50</y>
+          <y>70</y>
           <width>761</width>
           <height>81</height>
          </rect>
@@ -1331,7 +1331,8 @@ QTabBar::tab:!selected {
            </property>
            <property name="font">
             <font>
-             <family>.SF NS Text Condensed</family>
+             <family>Cantarell</family>
+             <pointsize>13</pointsize>
              <weight>75</weight>
              <bold>true</bold>
             </font>
@@ -1351,12 +1352,13 @@ QTabBar::tab:!selected {
            </property>
            <property name="font">
             <font>
+             <pointsize>13</pointsize>
              <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
            <property name="text">
-            <string>Restart
+            <string>Reboot
 Operative System</string>
            </property>
           </widget>
@@ -1371,6 +1373,7 @@ Operative System</string>
            </property>
            <property name="font">
             <font>
+             <pointsize>13</pointsize>
              <weight>75</weight>
              <bold>true</bold>
             </font>
@@ -1386,14 +1389,15 @@ Operative System</string>
        <widget class="QLabel" name="label_warning">
         <property name="geometry">
          <rect>
-          <x>180</x>
+          <x>80</x>
           <y>20</y>
-          <width>441</width>
-          <height>16</height>
+          <width>621</width>
+          <height>31</height>
          </rect>
         </property>
         <property name="font">
          <font>
+          <pointsize>15</pointsize>
           <weight>75</weight>
           <bold>true</bold>
          </font>

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -177,6 +177,10 @@ class StartStopWorker():
 
 
     def _stop_abruptly(self):
+        '''
+        If the hardware stops running, this 
+        changes the test in the bottons and status.
+        '''
         self.run = self.DONOT_RUN
         self.stop_button_pressed()
 

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -79,8 +79,11 @@ class StartStopWorker():
         '''
         if self.run == self.DONOT_RUN:
             self.button_startstop.setText("Start\n" + self.mode_text)
+            self.toolbar.set_stopped(self.mode_text)
         else:
             self.button_startstop.setText("Stop\n" + self.mode_text)
+            self.toolbar.set_running(self.mode_text)
+
 
     def start_button_pressed(self):
         '''

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -151,4 +151,12 @@ class StartStopWorker():
                 else:
                     self.raise_comm_error('Cannot stop ventilator.')
 
+    def set_run(self, run):
+        if self.run != run:
+            self.toggle_start_stop()
+
+    def set_mode(self, mode):
+        if self.mode != mode:
+            self.toggle_mode()
+
 

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -1,3 +1,7 @@
+'''
+A file from class StartStopWorker
+'''
+
 from PyQt5 import QtCore, QtGui, QtWidgets
 from messagebox import MessageBox
 
@@ -70,12 +74,18 @@ class StartStopWorker():
                 self.raise_comm_error('Cannot set automatic mode.')
 
     def update_startstop_text(self):
+        '''
+        Updates the text in the Start/Stop button
+        '''
         if self.run == self.DONOT_RUN:
             self.button_startstop.setText("Start\n" + self.mode_text)
         else:
             self.button_startstop.setText("Stop\n" + self.mode_text)
 
     def start_button_pressed(self):
+        '''
+        Callback for when the Start button is pressed
+        '''
         self.button_startstop.setDisabled(True)
         self.button_autoassist.setDisabled(True)
         self.button_startstop.repaint()
@@ -89,6 +99,9 @@ class StartStopWorker():
                  self.toolbar.set_running(self.mode_text)))
 
     def stop_button_pressed(self):
+        '''
+        Callback for when the Stop button is pressed
+        '''
         self.button_startstop.setEnabled(True)
         self.button_autoassist.setEnabled(True)
 
@@ -101,6 +114,10 @@ class StartStopWorker():
         self.toolbar.set_stopped(self.mode_text)
 
     def confirm_stop_pressed(self):
+        '''
+        Opens a window which asks for confirmation
+        when the Stop button is pressed.
+        '''
         self.button_autoassist.setDown(False)
         currentMode = self.mode_text.upper()
         msg = MessageBox()
@@ -113,6 +130,10 @@ class StartStopWorker():
 
 
     def button_timeout(self):
+        '''
+        Waits for some time before making 
+        the Stop button visible
+        '''
         timeout = 1000
         # Set timeout for being able to stop this mode
         if 'start_mode_timeout' in self.config:
@@ -152,10 +173,20 @@ class StartStopWorker():
                     self.raise_comm_error('Cannot stop ventilator.')
 
     def set_run(self, run):
+        '''
+        Sets the run variable directly.
+        Usually called at start up, when reading
+        the run value from the ESP.
+        '''
         if self.run != run:
             self.toggle_start_stop()
 
     def set_mode(self, mode):
+        '''
+        Sets the mode variable directly.
+        Usually called at start up, when reading
+        the mode value from the ESP.
+        '''
         if self.mode != mode:
             self.toggle_mode()
 

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -172,13 +172,29 @@ class StartStopWorker():
                 else:
                     self.raise_comm_error('Cannot stop ventilator.')
 
+
+    def _stop_abruptly(self):
+        self.run = self.DONOT_RUN
+        self.stop_button_pressed()
+
     def set_run(self, run):
         '''
         Sets the run variable directly.
         Usually called at start up, when reading
         the run value from the ESP.
         '''
-        if self.run != run:
+        if self.run == run:
+            return
+
+        if self.run == self.DO_RUN:
+            msg = MessageBox()
+            msg.critical('STOPPING VENTILATION',
+                         'The hardware has stopped the ventilation.', 
+                         'The microcontroller has stopped the ventilation by sending run = '+str(run),
+                         'The microcontroller has stopped the ventilation by sending run = '+str(run), 
+                         {msg.Ok: self._stop_abruptly})()
+
+        else:
             self.toggle_start_stop()
 
     def set_mode(self, mode):

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -70,8 +70,8 @@ String get(String const& command)
       + String(random(0, 1))       + "," // power_mode
       + String(random(1, 100))     + "," // battery
       + String(random(70, 80))     + "," // peak
-      + String(random(1000, 2000)  + "," // total_inspired_volume
-      + String(random(1000, 2000)  + "," // total_expired_volume
+      + String(random(1000, 2000)) + "," // total_inspired_volume
+      + String(random(1000, 2000)) + "," // total_expired_volume
       + String(random(10, 100));         // volume_minute
   }
 
@@ -108,7 +108,7 @@ void serial_loop(Stream& connection)
   }
 }
 
-void serial()
+void loop()
 {
   serial_loop(Serial);
   serial_loop(Debug);

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -32,6 +32,10 @@ void setup()
   parameters["alarm"] = String(0);
   parameters["warning"] = String(0);
 
+  parameters["run"]    = String(0);
+  parameters["mode"]   = String(0);
+  parameters["backup"] = String(0);
+
   parameters["rate"]             = String(12);
   parameters["ratio"]            = String(2);
   parameters["ptarget"]          = String(15);

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -31,6 +31,15 @@ void setup()
 
   parameters["alarm"] = String(0);
   parameters["warning"] = String(0);
+
+  parameters["rate"]             = String(12);
+  parameters["ratio"]            = String(2);
+  parameters["ptarget"]          = String(15);
+  parameters["assist_ptrigger"]  = String(1);
+  parameters["assist_flow_min"]  = String(20);
+  parameters["pressure_support"] = String(10);
+  parameters["backup_enable"]    = String(1);
+  parameters["backup_min_rate"]  = String(10);
 }
 
 // this is tricky, didn't had the time to think a better algo

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -60,15 +60,15 @@ String get(String const& command)
 
   if (name == "all") {
     return
-        String(random(10, 79))     + "," // pressure
+        String(random(20, 70))     + "," // pressure
       + String(random(3, 21))      + "," // flow
-      + String(random(10, 100))    + "," // o2
-      + String(random(12, 20))     + "," // bpm
+      + String(random(30, 100))    + "," // o2
+      + String(random(6, 8))       + "," // bpm
       + String(random(1000, 1500)) + "," // tidal
       + String(random(4, 20))      + "," // peep
       + String(random(10, 50))     + "," // temperature
       + String(random(0, 1))       + "," // power_mode
-      + String(random(1, 100))     + "," // battery
+      + String(random(20, 100))    + "," // battery
       + String(random(70, 80))     + "," // peak
       + String(random(1000, 2000)) + "," // total_inspired_volume
       + String(random(1000, 2000)) + "," // total_expired_volume


### PR DESCRIPTION
- Fixes #129 
- Fixes #132 
- Fixes #138 

**Issue 129**
- Adds `run`, `mode`, `backup` to mock.ino and fakeESP32serial
- Adds a new section in the fakeESP32serial window to control the `run`, `mode`, `backup` sent from the ESP:
![image](https://user-images.githubusercontent.com/17006198/79183036-f62ef500-7dd5-11ea-9408-b00e91506261.png)
- Adds a `ControllerStatus`class: a class entirely dedicated to constantly check the status of the ESP controller. Is it running? In which mode? Has it entered backup mode?
- Initializes the Settings to what is in the ESP. In more details: If the ESP is running, read the settings params from the ESP and update the values in the Settings panel. If the ESP is NOT running, don't do this, but follow the classic behavior. This is because if we click on "Continue Ventilation" we don't want to read the default parameters from the ESP, but we want to actively set the previously saved params to the ESP. And if we click on "New patient" we want to start from fresh parameters as well.

**Issue 132**
- Data samples are stored for 200 samples (configurable from the yaml file). 200 samples is about 20 seconds. The Y axis range is calculated based on the min and max over these 20 seconds (+- 10%). 
- We should test if this works well with the real hardware.

**Issue 138**
- Adds a "Special Operations" tab in the settings window.
- 3 buttons are present: `Software Upgrade`, `Restart Operative System`,  `Shut Down Operative System`
- If running the ventilator, the tab is still clickable but all the buttons in the tab are disabled.
- The buttons need to be connected to the appropriate callback in `Settings::connect_workers`, look for `# TODO`.