### PR TITLE
Issue 167

### DIFF
--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -251,7 +251,7 @@ void loop()
 {
   serial_loop(Serial);
   serial_loop(Debug);
-  
+
   if (parameters["wdenable"] == "1") {
     auto const now = mvm::now<mvm::Seconds>();
     if (now > gui_watchdog_expr) {

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -42,6 +42,32 @@ unsigned long now()
   return Time::from_micros(micros());
 }
 
+size_t send(Stream& connection, String const& data)
+{
+  auto const header = String("valore=");
+  auto const len = header.length() + data.length();
+  
+  auto sent = connection.print(header);
+  
+  auto pos = data.c_str();
+  
+  while (sent != len) {
+    auto const to_be_sent = len - sent;
+    auto const nbytes
+      = to_be_sent > SERIAL_TX_BUFFER_SIZE
+      ? SERIAL_TX_BUFFER_SIZE
+      : to_be_sent;
+
+    auto const written = connection.write(pos, nbytes);
+    pos += written;
+    sent += written;
+  }
+
+  sent += connection.println("");
+
+  return sent;
+}
+
 } // ns mvm
 
 unsigned long pause_lg_expiration = mvm::now<mvm::Seconds>() + 10;

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -19,7 +19,7 @@ std::map<String, String> parameters;
 
 std::vector<String> random_measures;
 
-namespace time {
+namespace mvm {
 
 struct Seconds
 {
@@ -42,9 +42,9 @@ unsigned long now()
   return Time::from_micros(micros());
 }
 
-} // ns time
+} // ns mvm
 
-unsigned long pause_lg_expiration = time::now<time::Seconds>() + 10;
+unsigned long pause_lg_expiration = mvm::now<mvm::Seconds>() + 10;
 
 void setup()
 {
@@ -95,7 +95,7 @@ String set(String const& command)
 
   if (name == "pause_lg" && value == "1") {
     pause_lg_expiration
-    = time::now<time::Seconds>()
+    = mvm::now<mvm::Seconds>()
     + parameters["pause_lg_time"].toInt();
   }
 
@@ -122,7 +122,7 @@ String get(String const& command)
       + String(random(1000, 2000)) + "," // total_expired_volume
       + String(random(10, 100));         // volume_minute
   } else if (name == "pause_lg_time") {
-    auto const now = time::now<time::Seconds>();
+    auto const now = mvm::now<mvm::Seconds>();
     return now > pause_lg_expiration ? "0" : String(pause_lg_expiration - now);
   }
 

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -98,6 +98,7 @@ mvm::alarm_t alarm_status = 0;
 mvm::alarm_t warning_status = 0;
 
 unsigned long pause_lg_expiration = mvm::now<mvm::Seconds>() + 10;
+unsigned long gui_watchdog_expr = mvm::now<mvm::Seconds>() + 5;
 
 void setup()
 {

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -176,11 +176,11 @@ void serial_loop(Stream& connection)
 
     if (command.length() == 0) {
     } else if (command_type == "get") {
-      connection.println("valore=" + get(command));
+      mvm::send(connection, get(command));
     } else if (command_type == "set") {
-      connection.println("valore=" + set(command));
+      mvm::send(connection, set(command));
     } else {
-      connection.println("valore=notok");
+      mvm::send(connection, "notok");
     }
   }
 }

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -112,6 +112,7 @@ void setup()
   parameters["run"]    = String(0);
   parameters["mode"]   = String(0);
   parameters["backup"] = String(0);
+  parameters["wdenable"] = String(0);
 
   parameters["pcv_trigger"]        = String(5);
   parameters["pcv_trigger_enable"] = String(0);
@@ -166,6 +167,9 @@ String set(String const& command)
   } else if (name == "_hwwarning") {
     warning_status = mvm::raise_hw_alarm(value.toInt(), warning_status);
     return "OK";
+  } else if (name == "wdenable" && value == "1") {
+    gui_watchdog_expr = mvm::now<mvm::Seconds>() + 5;
+    alarm_status = mvm::snooze_hw_alarm(30, alarm_status);
   } else {
     return "notok";
   }
@@ -246,4 +250,11 @@ void loop()
 {
   serial_loop(Serial);
   serial_loop(Debug);
+  
+  if (parameters.at("wdenable") == "1") {
+    auto const now = mvm::now<mvm::Seconds>();
+    if (now > gui_watchdog_expr) {
+      alarm_status = mvm::raise_hw_alarm(30, alarm_status);
+    }
+  }
 }

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -46,11 +46,11 @@ size_t send(Stream& connection, String const& data)
 {
   auto const header = String("valore=");
   auto const len = header.length() + data.length();
-  
+
   auto sent = connection.print(header);
-  
+
   auto pos = data.c_str();
-  
+
   while (sent != len) {
     auto const to_be_sent = len - sent;
     auto const nbytes

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -252,7 +252,7 @@ void loop()
   serial_loop(Serial);
   serial_loop(Debug);
   
-  if (parameters.at("wdenable") == "1") {
+  if (parameters["wdenable"] == "1") {
     auto const now = mvm::now<mvm::Seconds>();
     if (now > gui_watchdog_expr) {
       alarm_status = mvm::raise_hw_alarm(30, alarm_status);

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -89,6 +89,9 @@ void setup()
   parameters["mode"]   = String(0);
   parameters["backup"] = String(0);
 
+  parameters["pcv_trigger"]        = String(5);
+  parameters["pcv_trigger_enable"] = String(0);
+
   parameters["rate"]             = String(12);
   parameters["ratio"]            = String(2);
   parameters["ptarget"]          = String(15);

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -96,7 +96,7 @@ void setup()
   parameters["assist_flow_min"]  = String(20);
   parameters["pressure_support"] = String(10);
   parameters["backup_enable"]    = String(1);
-  parameters["backup_min_rate"]  = String(10);
+  parameters["backup_min_time"]  = String(10);
   parameters["pause_lg_time"]    = String(10);
 }
 

--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -97,7 +97,7 @@ void setup()
   parameters["pressure_support"] = String(10);
   parameters["backup_enable"]    = String(1);
   parameters["backup_min_rate"]  = String(10);
-  parameters["pause_lg_time"]    = "10";
+  parameters["pause_lg_time"]    = String(10);
 }
 
 // this is tricky, didn't had the time to think a better algo


### PR DESCRIPTION
hw mock-up updated:
- alarms are handled in the same fashion as for the ESP32 firmware
  - `set _hwalarm X` and
  - `set _hwwarning X` commands have been introduced to raise alarms and warnings
    at run-time by means of the debug external serial communication.
- a GUI watchdog is used
- operational parameters updated
- TX buffer overflows are prevented
- introduce an `mvm` namespace