### PR TITLE
Issue 179

### DIFF
--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -74,8 +74,6 @@ class Settings(QtWidgets.QMainWindow):
 
         self.load_presets()
 
-        self.tabWidget = self.tabs
-
     def spawn_presets_window(self, name):
         presets = self._config[name]['presets']
 
@@ -93,7 +91,7 @@ class Settings(QtWidgets.QMainWindow):
         self.inactivate_settings_buttons()
 
         # Always set the focus to the tab
-        self.tabWidget.setFocus()
+        self.tabs.setFocus()
 
 
     def hide_preset_worker(self):
@@ -107,7 +105,7 @@ class Settings(QtWidgets.QMainWindow):
         self.repaint()
 
         # Always set the focus to the tab
-        self.tabWidget.setFocus()
+        self.tabs.setFocus()
 
     def preset_worker(self):
 
@@ -126,13 +124,13 @@ class Settings(QtWidgets.QMainWindow):
         '''
         Inactivates all in the settings window
         '''
-        self.tabWidget.setDisabled(True)
+        self.tabs.setDisabled(True)
 
     def activate_settings_buttons(self):
         '''
         Activates all in the settings window
         '''
-        self.tabWidget.setEnabled(True)
+        self.tabs.setEnabled(True)
 
 
     def connect_workers(self):

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -74,6 +74,8 @@ class Settings(QtWidgets.QMainWindow):
 
         self.load_presets()
 
+        self.tabWidget = self.tabs
+
     def spawn_presets_window(self, name):
         presets = self._config[name]['presets']
 


### PR DESCRIPTION
- Fixes #179 
- `tabWidget` is now called `tabs` in `settings.py`
- I am keeping `tabWidget` in `settings.py`, and assigning `tabs` to it in the constructor. In this way, if `tabs` gets renamed again, we can see it when the GUI starts up, and not after trying to click on the presets window.