### PR TITLE
Issue 199

### DIFF
--- a/gui/communication/fake_esp32serial.py
+++ b/gui/communication/fake_esp32serial.py
@@ -59,7 +59,19 @@ class FakeESP32Serial(QtWidgets.QMainWindow):
             "backup": 0,
             "alarm": 0,
             "warning": 0,
-            "temperature": 40}
+            "temperature": 40,
+            "rate": 17.0,
+            "ratio": 2/3,
+            "ptarget": 37.7,
+            "pcv_trigger_enable": 1,
+            "pcv_trigger": 7,
+            "assist_ptrigger": 7.0,
+            "assist_flow_min": 47.0,
+            "pressure_support": 27.,
+            "backup_min_time": 17.0,
+            "backup_enable": 1,
+            "pause_lg_p": 37,
+            "pause_lg_time": 7.0}
 
         self.event_log = self.findChild(QtWidgets.QPlainTextEdit, "event_log")
         self.event_log.setReadOnly(True)

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -272,10 +272,12 @@ class Settings(QtWidgets.QMainWindow):
         self.toolsettings_lookup = {}
         self.toolsettings_lookup["respiratory_rate"] = self._toolsettings["toolsettings_1"]
         self.toolsettings_lookup["insp_expir_ratio"] = self._toolsettings["toolsettings_2"]
+        self.toolsettings_lookup["insp_pressure"] = self._toolsettings["toolsettings_3"]
 
         # setup the toolsettings with preset values
         self.toolsettings_lookup["respiratory_rate"].update(external_config["respiratory_rate"])
         self.toolsettings_lookup["insp_expir_ratio"].update(external_config["insp_expir_ratio"])
+        self.toolsettings_lookup["insp_pressure"].update(external_config["insp_pressure"])
 
         self.send_values_to_hardware()
 

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -65,8 +65,9 @@ class StartStopWorker():
             # parameters from the ESP and set those
             # values to the settings panels
             for param, esp_name in self._config['esp_settable_param'].items():
-                print('Reading Settings parameters from ESP:', param, self._esp32.get(esp_name))
-                self._settings.update_spinbox_value(param, float(self._esp32.get(esp_name)))
+                value = float(self._esp32.get(esp_name))
+                print('Reading Settings parameters from ESP:', param, value)
+                self._settings.update_spinbox_value(param, value)
 
 
     def _esp32_io(self):

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -56,12 +56,12 @@ class StartStopWorker():
 
         if self._run == self.DONOT_RUN:
             # If the ESP is NOT running, set the YAML parameters
-            # in the settings panels, and also send those 
+            # in the settings panels, and also send those
             # values to the ESP
             self._settings.load_presets()
             self._settings.send_values_to_hardware()
         else:
-            # If the ESP is running, read the current 
+            # If the ESP is running, read the current
             # parameters from the ESP and set those
             # values to the settings panels
             for param, esp_name in self._config['esp_settable_param'].items():

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -91,7 +91,6 @@ class StartStopWorker():
         run = int(self._esp32.get('run'))
         mode = int(self._esp32.get('mode'))
         backup = int(self._esp32.get('backup'))
-        print('Reading from ESP: run', run, 'mode', mode)
 
         if backup:
             if not self._backup_ackowledged:

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -67,7 +67,11 @@ class StartStopWorker():
             for param, esp_name in self._config['esp_settable_param'].items():
                 value = float(self._esp32.get(esp_name))
                 print('Reading Settings parameters from ESP:', param, value)
-                self._settings.update_spinbox_value(param, value)
+                if esp_name == 'ratio':
+                    converted_value = (value**-1 - 1)**-1
+                    self._settings.update_spinbox_value(param, converted_value)
+                else:
+                    self._settings.update_spinbox_value(param, value)
 
 
     def _esp32_io(self):

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -39,9 +39,34 @@ class StartStopWorker():
 
         self._esp32_io()
 
+        self._init_settings_panel()
+
         self._timer = QTimer()
         self._timer.timeout.connect(self._esp32_io)
         self._start_timer()
+
+    def _init_settings_panel(self):
+        '''
+        Initializes the settings values.
+        If the ESP if running, read the current parameters
+        and set them in the Setting panel.
+        If the ESP is not running, don't do anything here,
+        and leave the default behaviour.
+        '''
+
+        if self._run == self.DONOT_RUN:
+            # If the ESP is NOT running, set the YAML parameters
+            # in the settings panels, and also send those 
+            # values to the ESP
+            self._settings.load_presets()
+            self._settings.send_values_to_hardware()
+        else:
+            # If the ESP is running, read the current 
+            # parameters from the ESP and set those
+            # values to the settings panels
+            for param, esp_name in self._config['esp_settable_param'].items():
+                print('Reading Settings parameters from ESP:', param, self._esp32.get(esp_name))
+                self._settings.update_spinbox_value(param, float(self._esp32.get(esp_name)))
 
 
     def _esp32_io(self):


### PR DESCRIPTION
Fixes #199 
Adds a method called `_init_settings_panel` to `StartStopWorker` class.
This method is only called at initialization. 
It checks if the ESP is running or not and:
- If the ESP is NOT running, it sets the YAML default values to the ESP
- If the ESP is running, it reads the ESP values and sets them to the setting panel

If the user then clicks on `Resume Ventilation` then the settings are loaded from the settings.txt.