### PR TITLE
Return firmware version

### DIFF
--- a/mock/mock.ino
+++ b/mock/mock.ino
@@ -211,6 +211,8 @@ String get(String const& command)
     return String(alarm_status);
   } else if (name == "warning") {
     return String(warning_status);
+  } else if (name == "version") {
+    return "mock";
   }
 
   auto const it = std::find(


### PR DESCRIPTION
Added option to return firmware version (`get version`), same as in the MVM firmware.