### PR TITLE
Issue 237

### DIFF
--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -20,7 +20,7 @@ get_all_fields:
   - volume_minute
 
 # Path to upgrade script
-upgrade_script: "cd /home/pi/upgrade.gui/gui/; python mvm_update.py"
+upgrade_script: "cd /home/pi/upgrade.gui/gui/; python3 mvm_update.py"
 
 # Conversion factors to apply to the values from the get_all
 conversions:

--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -19,6 +19,9 @@ get_all_fields:
   - total_expired_volume
   - volume_minute
 
+# Path to upgrade script
+upgrade_script: "cd /home/pi/upgrade.gui/gui/; python mvm_update.py"
+
 # Conversion factors to apply to the values from the get_all
 conversions:
     pressure: 1.01972 # mbar to cmH2O

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -6,7 +6,7 @@ Settings ui helper
 import os
 import sys
 import copy
-from PyQt5 import QtWidgets, uic
+from PyQt5 import QtWidgets, QtCore, uic
 from presets.presets import Presets
 from messagebox import MessageBox
 from communication import ESP32Exception
@@ -38,6 +38,7 @@ class Settings(QtWidgets.QMainWindow):
         self._config = self.mainparent.config
         self._data_h = self.mainparent._data_h
         self._toolsettings = self.mainparent.toolsettings
+        self._messagebar = self.mainparent.messagebar
         # self._start_stop_worker = self.mainparent._start_stop_worker
 
         # This contains all the default params
@@ -232,8 +233,23 @@ class Settings(QtWidgets.QMainWindow):
 
         # Special operations
         self.label_warning.setVisible(False)
-        self.btn_sw_update.clicked.connect(lambda: print(
-            'Sw update button clicked, but not implemented.'))
+        self.btn_sw_update.clicked.connect(lambda: self._messagebar.get_confirmation(
+            "Confirm SOFTWARE UPDATE AND CLOSE",
+            "Are you sure you want to request and execute a SOFTWARE UPDATE and CLOSE?",
+            func_confirm=self.upgrade_and_exit,
+            color="red"))
+
+    def upgrade_and_exit(self):
+        upgrade = QtCore.QProcess()
+        cmd = self._config['upgrade_script']
+
+        print("Running \"%s\"..." % cmd) 
+        upgrade.start(cmd)
+        upgrade.setProcessChannelMode(QtCore.QProcess.ForwardedChannels);
+        upgrade.waitForFinished()
+        upgrade.close()
+        print("Complete. Closing GUI.")
+        sys.exit(0)
 
     def load_presets(self):
         '''

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -231,14 +231,9 @@ class Settings(QtWidgets.QMainWindow):
                 btn.valueChanged.connect(self.worker)
 
         # Special operations
-        # TODO: implement the function to associate to buttons
         self.label_warning.setVisible(False)
         self.btn_sw_update.clicked.connect(lambda: print(
             'Sw update button clicked, but not implemented.'))
-        self.btn_restart_os.clicked.connect(lambda: print(
-            'OS restart button clicked, but not implemented.'))
-        self.btn_shut_down_os.clicked.connect(lambda: print(
-            'OS shut down button clicked, but not implemented.'))
 
     def load_presets(self):
         '''

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -6,7 +6,7 @@ Settings ui helper
 import os
 import sys
 import copy
-from PyQt5 import QtWidgets, QtCore, uic
+from PyQt5 import QtWidgets, uic
 from presets.presets import Presets
 from messagebox import MessageBox
 from communication import ESP32Exception
@@ -240,14 +240,10 @@ class Settings(QtWidgets.QMainWindow):
             color="red"))
 
     def upgrade_and_exit(self):
-        upgrade = QtCore.QProcess()
         cmd = self._config['upgrade_script']
 
         print("Running \"%s\"..." % cmd) 
-        upgrade.start(cmd)
-        upgrade.setProcessChannelMode(QtCore.QProcess.ForwardedChannels);
-        upgrade.waitForFinished()
-        upgrade.close()
+        os.system(cmd)
         print("Complete. Closing GUI.")
         sys.exit(0)
 

--- a/gui/settings/settings.ui
+++ b/gui/settings/settings.ui
@@ -105,7 +105,7 @@ QTabBar::tab:!selected {
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="iconSize">
        <size>
@@ -2525,107 +2525,81 @@ border: 2px solid gray;
        <attribute name="title">
         <string>Maintenance</string>
        </attribute>
-       <widget class="QWidget" name="horizontalLayoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>70</y>
-          <width>761</width>
-          <height>81</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="sizeConstraint">
-          <enum>QLayout::SetNoConstraint</enum>
-         </property>
-         <item>
-          <widget class="QPushButton" name="btn_sw_update">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <family>Cantarell</family>
-             <pointsize>13</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Software Upgrade </string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="btn_restart_os">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Reboot
-Operative System</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="btn_shut_down_os">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>13</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Shut Down
-Operative System</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QLabel" name="label_warning">
-        <property name="geometry">
-         <rect>
-          <x>80</x>
-          <y>20</y>
-          <width>620</width>
-          <height>30</height>
-         </rect>
-        </property>
-        <property name="font">
-         <font>
-          <pointsize>15</pointsize>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>These settings are only available when the ventilator is not running.</string>
-        </property>
-       </widget>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="label_warning">
+          <property name="font">
+           <font>
+            <pointsize>15</pointsize>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>These settings are only available when the ventilator is not running.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="sizeConstraint">
+           <enum>QLayout::SetNoConstraint</enum>
+          </property>
+          <item>
+           <widget class="QPushButton" name="btn_sw_update">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>75</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>300</width>
+              <height>75</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>Cantarell</family>
+              <pointsize>13</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Software Upgrade </string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </widget>
      </widget>
     </item>

--- a/gui/settings/settings.ui
+++ b/gui/settings/settings.ui
@@ -2562,7 +2562,7 @@ border: 2px solid gray;
             <property name="minimumSize">
              <size>
               <width>0</width>
-              <height>75</height>
+              <height>100</height>
              </size>
             </property>
             <property name="maximumSize">
@@ -2585,19 +2585,6 @@ border: 2px solid gray;
            </widget>
           </item>
          </layout>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
Fixed #237 

- Removed all maintenance tab buttons except for Software Upgrade
- User must confirm upgrade (`MessageBar` confirmation)
- Added functionality to run upgrade script (command configurable from `default_settings`). **I can see arguments for making this configurable or hard-coded. Let me know which is preferable**