### PR TITLE
Issue #240 - vary toolsettings bar for PSV/PCV

### DIFF
--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -234,6 +234,12 @@ monitors:
         alarmcolor: "red"
         observable: peak
 
+# Up to 3 settings may be shown in the bottom bar.
+# Which are shown varies based on the current mode.
+displayed_toolsettings:
+    psv: ['support_pressure']
+    pcv: ['respiratory_rate', 'insp_expir_ratio', 'insp_pressure']
+
 displayed_monitors:
     - battery_charge
     - battery_powered

--- a/gui/mainwindow.py
+++ b/gui/mainwindow.py
@@ -137,15 +137,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.label_status = self.toolbar.findChild(
             QtWidgets.QLabel, "label_status")
 
-        toolsettings_names = {"toolsettings_1",
-                              "toolsettings_2", "toolsettings_3"}
-        self.toolsettings = {}
-
-        for name in toolsettings_names:
-            toolsettings = self.toolbar.findChild(QtWidgets.QWidget, name)
-            toolsettings.connect_config(config)
-            self.toolsettings[name] = toolsettings
-
         # Get menu widgets and connect settings for the menu widget
         self.button_back = self.menu.findChild(
             QtWidgets.QPushButton, "button_back")

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -244,7 +244,7 @@ class Settings(QtWidgets.QMainWindow):
     def upgrade_and_exit(self):
         cmd = self._config['upgrade_script']
 
-        print("Running \"%s\"..." % cmd) 
+        print("Running \"%s\"..." % cmd)
         os.system(cmd)
         print("Complete. Closing GUI.")
         sys.exit(0)
@@ -273,35 +273,35 @@ class Settings(QtWidgets.QMainWindow):
         """
         When the mode changes between PSV/PCV, we need to change which toolsettings
         are shown in the bottom bar.
-        
+
         Arguments:
         - is_psv (bool): Whether PSV or PCV is now active
         """
         self.toolsettings_lookup = {}
-        
+
         mode = 'psv' if is_psv else 'pcv'
         tool_list = self._config["displayed_toolsettings"][mode]
-        
+
         self.toolsettings_lookup = {}
-        
+
         # At most 3 tools can be shown
         for idx in range(3):
             widget = self._toolsettings["toolsettings_%d" % (idx + 1)]
-            
             if len(tool_list) > idx:
+
                 # Show the widget and assign an easy lookup
                 widget.load_presets(tool_list[idx])
                 self.toolsettings_lookup[tool_list[idx]] = widget
             else:
                 # Hide the widget
                 widget.load_presets(None)
-               
+
         # When this class is being constructed, we haven't
         # read any values, so will just leave the toolsettings
         # as their default values.
         if len(self._current_values) > 0:
             self.update_toolsettings_values()
-        
+
     def close_settings_worker(self):
         '''
         Closes the settings window, w/o applying

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -269,16 +269,15 @@ class Settings(QtWidgets.QMainWindow):
 
         self.repaint()
 
-    def mode_changed(self, is_psv):
+    def _set_mode(self, mode):
         """
-        When the mode changes between PSV/PCV, we need to change which toolsettings
-        are shown in the bottom bar.
+        Set the mode to PSV or PCV depending on the parameter and sets the
+        toolsetting shown in the bottom bar.
 
         Arguments:
-        - is_psv (bool): Whether PSV or PCV is now active
+        - mode (string): 'psv' or 'pcv'
         """
 
-        mode = 'psv' if is_psv else 'pcv'
         tool_list = self._config["displayed_toolsettings"][mode]
 
         self.toolsettings_lookup = {}

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -277,7 +277,6 @@ class Settings(QtWidgets.QMainWindow):
         Arguments:
         - is_psv (bool): Whether PSV or PCV is now active
         """
-        self.toolsettings_lookup = {}
 
         mode = 'psv' if is_psv else 'pcv'
         tool_list = self._config["displayed_toolsettings"][mode]

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -300,7 +300,7 @@ class Settings(QtWidgets.QMainWindow):
         # When this class is being constructed, we haven't
         # read any values, so will just leave the toolsettings
         # as their default values.
-        if len(self._current_values) > 0:
+        if self._current_values:
             self.update_toolsettings_values()
 
     def close_settings_worker(self):

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -92,7 +92,7 @@ class Settings(QtWidgets.QMainWindow):
         self._all_spinboxes['insp_expir_ratio'].valueChanged.connect(
             self._recalculate_inspiratory_time)
 
-        self.toolsettings_lookup = None
+        self.toolsettings_lookup = {}
 
         # Connect all widgets
         self.connect_workers()
@@ -101,6 +101,8 @@ class Settings(QtWidgets.QMainWindow):
         self._current_preset = None
         self._current_preset_name = None
 
+        # Default to PCV setup; will be updated by start_stop_worker.
+        self.mode_changed(False)
         self.load_presets()
 
     def _recalculate_inspiratory_time(self):
@@ -262,23 +264,38 @@ class Settings(QtWidgets.QMainWindow):
             btn.setValue(value_config['default'])
             self._current_values[param] = value_config['default']
 
-        # assign an easy lookup for toolsettings
-        self.toolsettings_lookup = {}
-        self.toolsettings_lookup["respiratory_rate"] = self._toolsettings["toolsettings_1"]
-        self.toolsettings_lookup["insp_expir_ratio"] = self._toolsettings["toolsettings_2"]
-        self.toolsettings_lookup["insp_pressure"] = self._toolsettings["toolsettings_3"]
-
-        # setup the toolsettings with preset values
-        self.toolsettings_lookup["respiratory_rate"].load_presets(
-            "respiratory_rate")
-        self.toolsettings_lookup["insp_expir_ratio"].load_presets(
-            "insp_expir_ratio")
-        self.toolsettings_lookup["insp_pressure"].load_presets("insp_pressure")
 
         self._current_values_temp = copy.copy(self._current_values)
 
         self.repaint()
 
+    def mode_changed(self, is_psv):
+        """
+        When the mode changes between PSV/PCV, we need to change which toolsettings
+        are shown in the bottom bar.
+        
+        Arguments:
+        - is_psv (bool): Whether PSV or PCV is now active
+        """
+        self.toolsettings_lookup = {}
+        
+        mode = 'psv' if is_psv else 'pcv'
+        tool_list = self._config["displayed_toolsettings"][mode]
+        
+        self.toolsettings_lookup = {}
+        
+        # At most 3 tools can be shown
+        for idx in range(3):
+            widget = self._toolsettings["toolsettings_%d" % (idx + 1)]
+            
+            if len(tool_list) > idx:
+                # Show the widget and assign an easy lookup
+                widget.load_presets(tool_list[idx])
+                self.toolsettings_lookup[tool_list[idx]] = widget
+            else:
+                # Hide the widget
+                widget.load_presets(None)
+        
     def close_settings_worker(self):
         '''
         Closes the settings window, w/o applying
@@ -309,13 +326,6 @@ class Settings(QtWidgets.QMainWindow):
         else:
             raise Exception('Cannot set value to SpinBox with name', param)
 
-        if self.toolsettings_lookup is None:
-            raise Exception(
-                'Trying to update SpinBox values but toolsettings_lookup was not set!')
-
-        if param in self.toolsettings_lookup:
-            self.toolsettings_lookup[param].update(value)
-
     def update_config(self, external_config):
         '''
         Loads the presets from the config file
@@ -329,20 +339,6 @@ class Settings(QtWidgets.QMainWindow):
 
             btn.setValue(value)
             self._current_values[param] = value
-
-        # assign an easy lookup for toolsettings
-        self.toolsettings_lookup = {}
-        self.toolsettings_lookup["respiratory_rate"] = self._toolsettings["toolsettings_1"]
-        self.toolsettings_lookup["insp_expir_ratio"] = self._toolsettings["toolsettings_2"]
-        self.toolsettings_lookup["insp_pressure"] = self._toolsettings["toolsettings_3"]
-
-        # setup the toolsettings with preset values
-        self.toolsettings_lookup["respiratory_rate"].update(
-            external_config["respiratory_rate"])
-        self.toolsettings_lookup["insp_expir_ratio"].update(
-            external_config["insp_expir_ratio"])
-        self.toolsettings_lookup["insp_pressure"].update(
-            external_config["insp_pressure"])
 
         self.send_values_to_hardware()
 
@@ -405,13 +401,8 @@ class Settings(QtWidgets.QMainWindow):
                              {msg.Retry: lambda: self.send_values_to_hardware,
                               msg.Abort: lambda: sys.exit(-1)})()
 
-            if param == 'respiratory_rate':
-                self.toolsettings_lookup["respiratory_rate"].update(value)
-            elif param == 'insp_expir_ratio':
-                self.toolsettings_lookup["insp_expir_ratio"].update(
-                    self._current_values[param])
-            elif param == 'insp_pressure':
-                self.toolsettings_lookup["insp_pressure"].update(value)
+            if param in self.toolsettings_lookup:
+                self.toolsettings_lookup[param].update(self._current_values[param])
 
         settings_file = SettingsFile(self._config["settings_file_path"])
         settings_file.store(settings_to_file)

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -285,10 +285,11 @@ class Settings(QtWidgets.QMainWindow):
         self.toolsettings_lookup = {}
 
         # At most 3 tools can be shown
+        len_tool_list = len(tool_list)
         for idx in range(3):
             widget = self._toolsettings["toolsettings_%d" % (idx + 1)]
-            if len(tool_list) > idx:
 
+            if len_tool_list > idx:
                 # Show the widget and assign an easy lookup
                 widget.load_presets(tool_list[idx])
                 self.toolsettings_lookup[tool_list[idx]] = widget

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -295,6 +295,12 @@ class Settings(QtWidgets.QMainWindow):
             else:
                 # Hide the widget
                 widget.load_presets(None)
+               
+        # When this class is being constructed, we haven't
+        # read any values, so will just leave the toolsettings
+        # as their default values.
+        if len(self._current_values) > 0:
+            self.update_toolsettings_values()
         
     def close_settings_worker(self):
         '''
@@ -401,11 +407,17 @@ class Settings(QtWidgets.QMainWindow):
                              {msg.Retry: lambda: self.send_values_to_hardware,
                               msg.Abort: lambda: sys.exit(-1)})()
 
-            if param in self.toolsettings_lookup:
-                self.toolsettings_lookup[param].update(self._current_values[param])
-
+        self.update_toolsettings_values()
         settings_file = SettingsFile(self._config["settings_file_path"])
         settings_file.store(settings_to_file)
+
+    def update_toolsettings_values(self):
+        '''
+        Update the values shown in the bottom toolsettings boxes
+        with the current values of the parameters.
+        '''
+        for param, toolsetting in self.toolsettings_lookup.items():
+            toolsetting.update(self._current_values[param])
 
     def worker(self):
         '''

--- a/gui/settings/settings.py
+++ b/gui/settings/settings.py
@@ -102,7 +102,7 @@ class Settings(QtWidgets.QMainWindow):
         self._current_preset_name = None
 
         # Default to PCV setup; will be updated by start_stop_worker.
-        self.mode_changed(False)
+        self.set_pcv()
         self.load_presets()
 
     def _recalculate_inspiratory_time(self):
@@ -268,6 +268,20 @@ class Settings(QtWidgets.QMainWindow):
         self._current_values_temp = copy.copy(self._current_values)
 
         self.repaint()
+
+    def set_pcv(self):
+        """
+        Inform that the current ventilation mode is PCV
+        """
+
+        self._set_mode("pcv")
+
+    def set_psv(self):
+        """
+        Inform that the current ventilation mode is PSV
+        """
+
+        self._set_mode("psv")
 
     def _set_mode(self, mode):
         """

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -91,6 +91,8 @@ class StartStopWorker():
                     self._settings.update_spinbox_value(param, converted_value)
                 else:
                     self._settings.update_spinbox_value(param, value)
+    
+            self._settings.update_toolsettings_values()
 
     def _esp32_io(self):
         '''

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -60,6 +60,9 @@ class StartStopWorker():
         self._timer = QTimer()
         self._timer.timeout.connect(self._esp32_io)
         self._start_timer()
+        
+        # Tell the Settings widget what the current mode is.
+        self._settings.mode_changed(self._mode == self.MODE_PSV)
 
     def _init_settings_panel(self):
         '''
@@ -185,6 +188,7 @@ class StartStopWorker():
                 self._button_mode.setText("Set\nPCV")
                 self.update_startstop_text()
                 self._mode = self.MODE_PSV
+                self._settings.mode_changed(True)
             else:
                 self._raise_comm_error('Cannot set PSV mode.')
 
@@ -196,6 +200,7 @@ class StartStopWorker():
                 self._button_mode.setText("Set\nPSV")
                 self.update_startstop_text()
                 self._mode = self.MODE_PCV
+                self._settings.mode_changed(False)
             else:
                 self._raise_comm_error('Cannot set PCV mode.')
 

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -60,7 +60,7 @@ class StartStopWorker():
         self._timer = QTimer()
         self._timer.timeout.connect(self._esp32_io)
         self._start_timer()
-        
+
         # Tell the Settings widget what the current mode is.
         self._settings.mode_changed(self._mode == self.MODE_PSV)
 
@@ -91,7 +91,7 @@ class StartStopWorker():
                     self._settings.update_spinbox_value(param, converted_value)
                 else:
                     self._settings.update_spinbox_value(param, value)
-    
+
             self._settings.update_toolsettings_values()
 
     def _esp32_io(self):

--- a/gui/start_stop_worker.py
+++ b/gui/start_stop_worker.py
@@ -62,7 +62,10 @@ class StartStopWorker():
         self._start_timer()
 
         # Tell the Settings widget what the current mode is.
-        self._settings.mode_changed(self._mode == self.MODE_PSV)
+        if self._mode == self.MODE_PSV:
+            self._settings.set_psv()
+        else:
+            self._settings.set_pcv()
 
     def _init_settings_panel(self):
         '''
@@ -190,7 +193,7 @@ class StartStopWorker():
                 self._button_mode.setText("Set\nPCV")
                 self.update_startstop_text()
                 self._mode = self.MODE_PSV
-                self._settings.mode_changed(True)
+                self._settings.set_psv()
             else:
                 self._raise_comm_error('Cannot set PSV mode.')
 
@@ -202,7 +205,7 @@ class StartStopWorker():
                 self._button_mode.setText("Set\nPSV")
                 self.update_startstop_text()
                 self._mode = self.MODE_PCV
-                self._settings.mode_changed(False)
+                self._settings.set_pcv()
             else:
                 self._raise_comm_error('Cannot set PCV mode.')
 

--- a/gui/toolsettings/toolsettings.py
+++ b/gui/toolsettings/toolsettings.py
@@ -92,7 +92,7 @@ class ToolSettings(QtWidgets.QWidget):
             self.labels["units"].setText("")
 
         self.update(val)
-        
+
     def load_presets(self, name="default"):
         """
         Configure this widget by loading values from the configuration file.
@@ -108,7 +108,7 @@ class ToolSettings(QtWidgets.QWidget):
             # just make everything empty.
             for label in self.labels.values():
                 label.setText("")
-            
+
             self.slider_value.hide()
         else:
             self.slider_value.show()
@@ -173,7 +173,7 @@ class ToolSettings(QtWidgets.QWidget):
             disp_value = "1:%.2g" % value
         else:
             # Display decimal/integer
-            disp_value = "%g" % (round(value / self.step) * self.step)
+            disp_value = str(value).rstrip('0').rstrip('.')
 
         slider_value = int((value - self.min) / self.step)
         self.slider_value.setValue(slider_value)

--- a/gui/toolsettings/toolsettings.py
+++ b/gui/toolsettings/toolsettings.py
@@ -92,7 +92,7 @@ class ToolSettings(QtWidgets.QWidget):
             self.labels["units"].setText("")
 
         self.update(val)
-
+        
     def load_presets(self, name="default"):
         """
         Configure this widget by loading values from the configuration file.
@@ -100,26 +100,37 @@ class ToolSettings(QtWidgets.QWidget):
         Arguments:
         - name: The attribute to look for in the YAML file. If the attribute is not
             found, default values will be loaded instead (no warning/exception).
+            If the name is None, then the widget will be empty.
         """
-        toolsettings_default = {
-            "name": "Param",
-            "default": 50,
-            "min": 0,
-            "max": 100,
-            "current": None,
-            "units": "-",
-            "step": 1,
-            "show_fraction": False}
-        entry = self._config.get(name, toolsettings_default)
-        self.setup(
-            entry.get("name", toolsettings_default["name"]),
-            setrange=(
-                entry.get("min", toolsettings_default["min"]),
-                entry.get("default", toolsettings_default["default"]),
-                entry.get("max", toolsettings_default["max"])),
-            units=entry.get("units", toolsettings_default["units"]),
-            step=entry.get("step", toolsettings_default["step"]),
-            show_fraction=entry.get("show_fraction", toolsettings_default["show_fraction"]))
+        if name is None:
+            # It would be cleaner to hide the entire widget, but that affects the
+            # position of other elements. So we keep the widget around, and
+            # just make everything empty.
+            for label in self.labels.values():
+                label.setText("")
+            
+            self.slider_value.hide()
+        else:
+            self.slider_value.show()
+            toolsettings_default = {
+                "name": "Param",
+                "default": 50,
+                "min": 0,
+                "max": 100,
+                "current": None,
+                "units": "-",
+                "step": 1,
+                "show_fraction": False}
+            entry = self._config.get(name, toolsettings_default)
+            self.setup(
+                entry.get("name", toolsettings_default["name"]),
+                setrange=(
+                    entry.get("min", toolsettings_default["min"]),
+                    entry.get("default", toolsettings_default["default"]),
+                    entry.get("max", toolsettings_default["max"])),
+                units=entry.get("units", toolsettings_default["units"]),
+                step=entry.get("step", toolsettings_default["step"]),
+                show_fraction=entry.get("show_fraction", toolsettings_default["show_fraction"]))
 
     def connect_config(self, config):
         """


### PR DESCRIPTION
`StartStopWorker` tells `Settings` when the mode changes, and `Settings` then reconfigures the toolsettings widgets.