### PR TITLE
Changed ETS range to 5-60%

### DIFF
--- a/gui/default_settings.yaml
+++ b/gui/default_settings.yaml
@@ -450,17 +450,17 @@ pressure_trigger:
 flow_trigger: 
     name: "Flow Trigger"
     default: 30.
-    min: 0.
-    max: 50.
+    min: 5.
+    max: 60.
     step: 1
     current: None
     presets:
         - [10, '']
-        - [15, '']
         - [20, '']
-        - [25, '']
         - [30, '']
-        - [35, '']
+        - [40, '']
+        - [50, '']
+        - [60, '']
 
 # Support Pressure
 support_pressure:


### PR DESCRIPTION
Fixed #265 

- The range for ETS (under `flow_trigger` in `default_settings.yaml`) changed to 5-60